### PR TITLE
Allow StructArray arguments in CUDAnative kernels.

### DIFF
--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -17,6 +17,10 @@ include("sort.jl")
 include("groupjoin.jl")
 include("lazy.jl")
 
+# Use Adapt allows for automatic conversion of CPU to GPU StructArrays
+import Adapt
+Adapt.adapt_storage(to, s::StructArray) = replace_storage(x->Adapt.adapt(to, x), s)
+
 function __init__()
     Requires.@require Tables="bd369af6-aec1-5ad0-b16a-f7cc5008161c" include("tables.jl")
     Requires.@require WeakRefStrings="ea10d353-3f73-51f8-a26c-33c1cb351aa5" begin

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -134,11 +134,11 @@ Base.axes(s::StructArray) = axes(fieldarrays(s)[1])
 Base.axes(s::StructArray{<:Any, <:Any, <:EmptyTup}) = (1:0,)
 
 get_ith(cols::NamedTuple, I...) = get_ith(Tuple(cols), I...)
-function get_ith(cols::NTuple{N, Any}, I...) where N
-    ntuple(N) do i
-        @inbounds res = getfield(cols, i)[I...]
-        return res
+@generated function get_ith(cols::NTuple{N, Any}, I...) where N
+    args = ntuple(N) do i
+        :(@inbounds res = getfield(cols, $i)[I...])
     end
+    :(($(args...),))
 end
 
 Base.@propagate_inbounds function Base.getindex(x::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, I::Vararg{Int, N}) where {T, N}


### PR DESCRIPTION
These changes allow `StructArray`s to be use as arguments to `CUDAnative` kernels and allows `getindex` and `setindex!` to be called.  For example the following code now works

```julia
using CUDAnative, CuArrays, StaticArrays, StructArrays

c = [SHermitianCompact(@SVector(rand(3))) for i=1:5]
d = StructArray(c, unwrap = t -> t <: Union{SHermitianCompact,SVector,Tuple})

dd = replace_storage(CuArray, d)
de = similar(dd)

@show typeof(dd)

function kernel!(dest, src)
    i = (blockIdx().x-1)*blockDim().x + threadIdx().x
    if i <= length(dest)
        dest[i] = src[i]
    end
    return nothing
end

threads = 1024
blocks = cld(length(dd),threads)

@cuda threads=threads blocks=blocks kernel!(de, dd)
```