### PR TITLE
Implement three-argument `similar` methods

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -102,16 +102,20 @@ end
 
 Base.similar(s::StructArray, sz::Base.DimOrInd...) = similar(s, Base.to_shape(sz))
 Base.similar(s::StructArray) = similar(s, Base.to_shape(axes(s)))
-function Base.similar(s::StructArray{T,N,C}, ::Type{T}, sz::NTuple{N,Int64}) where {T, N, C<:Union{Tuple, NamedTuple}}
+function Base.similar(s::StructArray{T,N,C}, ::Type{T}, sz::NTuple{M,Int64}) where {T, N, M, C<:Union{Tuple, NamedTuple}}
     StructArray{T}(map(typ -> similar(typ, sz), fieldarrays(s)))
 end
 
-function Base.similar(s::StructArray{T,N,C}, S::Type, sz::NTuple{N,Int64}) where {T, N, C<:Union{Tuple, NamedTuple}}
+function Base.similar(s::StructArray{T,N,C}, S::Type, sz::NTuple{M,Int64}) where {T, N, M, C<:Union{Tuple, NamedTuple}}
     # If not specified, we don't really know what kind of array to use for each
     # interior type, so we just pick the first one arbitrarily. If users need
     # something else, they need to be more specific.
     f1 = fieldarrays(s)[1]
-    buildfromschema(typ -> similar(f1, typ, sz), S)
+    if isstructtype(S)
+        return StructArrays.buildfromschema(typ -> similar(f1, typ, sz), S)
+    else
+        return similar(f1, S, sz)
+    end
 end
 
 """

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -102,8 +102,16 @@ end
 
 Base.similar(s::StructArray, sz::Base.DimOrInd...) = similar(s, Base.to_shape(sz))
 Base.similar(s::StructArray) = similar(s, Base.to_shape(axes(s)))
-function Base.similar(s::StructArray{T}, sz::Tuple) where {T}
+function Base.similar(s::StructArray{T,N,C}, ::Type{T}, sz::NTuple{N,Int64}) where {T, N, C<:Union{Tuple, NamedTuple}}
     StructArray{T}(map(typ -> similar(typ, sz), fieldarrays(s)))
+end
+
+function Base.similar(s::StructArray{T,N,C}, S::Type, sz::NTuple{N,Int64}) where {T, N, C<:Union{Tuple, NamedTuple}}
+    # If not specified, we don't really know what kind of array to use for each
+    # interior type, so we just pick the first one arbitrarily. If users need
+    # something else, they need to be more specific.
+    f1 = fieldarrays(s)[1]
+    buildfromschema(typ -> similar(f1, typ, sz), S)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -646,3 +646,9 @@ end
     str = String(take!(io))
     @test str == "StructArray(::Array{Int64,1}, ::Array{Int64,1})"
 end
+
+@testset "OffsetArray zero" begin
+    s = StructArray{ComplexF64}((rand(2), rand(2)))
+    soff = OffsetArray(s, 0:1)
+    @test isa(zero(soff).parent, StructArray)
+end


### PR DESCRIPTION
Array wrappers such as `OffsetArray` assume that the three argument
version exists for its interior arrays.

Also cc @mbauman for array expertise.