### PR TITLE
Add StructArrays.append!!

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,14 +214,16 @@ StructArray(s)
 
 ## Advanced: mutate-or-widen style accumulation
 
-StructArrays provides `grow_to_structarray!(dest, src)` which works like `append!(dest, src)` if `dest` can contain all element types in `src` iterator; i.e., it _mutates_ `dest` in-place:
+StructArrays provides a function `StructArrays.append!!(dest, src)` (unexported) for "mutate-or-widen" style accumulation.  This function can be used via [`BangBang.append!!`](https://tkf.github.io/BangBang.jl/dev/#BangBang.append!!-Tuple{Any,Any}) and [`BangBang.push!!`](https://tkf.github.io/BangBang.jl/dev/#BangBang.push!!-Tuple{Any,Any,Any,Vararg{Any,N}%20where%20N}) as well.
+
+`StructArrays.append!!` works like `append!(dest, src)` if `dest` can contain all element types in `src` iterator; i.e., it _mutates_ `dest` in-place:
 
 ```julia
 julia> dest = StructVector((a=[1], b=[2]))
 1-element StructArray(::Array{Int64,1}, ::Array{Int64,1}) with eltype NamedTuple{(:a, :b),Tuple{Int64,Int64}}:
  (a = 1, b = 2)
 
-julia> StructArrays.grow_to_structarray!(dest, [(a = 3, b = 4)])
+julia> StructArrays.append!!(dest, [(a = 3, b = 4)])
 2-element StructArray(::Array{Int64,1}, ::Array{Int64,1}) with eltype NamedTuple{(:a, :b),Tuple{Int64,Int64}}:
  (a = 1, b = 2)
  (a = 3, b = 4)
@@ -230,10 +232,10 @@ julia> ans === dest
 true
 ```
 
-Unlike `append!`, `grow_to_structarray!` can _widen_ element type of `dest` array element types:
+Unlike `append!`, `append!!` can also _widen_ element type of `dest` array element types:
 
 ```julia
-julia> StructArrays.grow_to_structarray!(dest, [(a = missing, b = 6)])
+julia> StructArrays.append!!(dest, [(a = missing, b = 6)])
 3-element StructArray(::Array{Union{Missing, Int64},1}, ::Array{Int64,1}) with eltype NamedTuple{(:a, :b),Tuple{Union{Missing, Int64},Int64}}:
  NamedTuple{(:a, :b),Tuple{Union{Missing, Int64},Int64}}((1, 2))
  NamedTuple{(:a, :b),Tuple{Union{Missing, Int64},Int64}}((3, 4))
@@ -243,6 +245,6 @@ julia> ans === dest
 false
 ```
 
-Since the original array `dest` cannot hold input, notice that a new array is created (`ans !== dest`).
+Since the original array `dest` cannot hold the input, a new array is created (`ans !== dest`).
 
-Combined with [function barriers](https://docs.julialang.org/en/latest/manual/performance-tips/#kernel-functions-1), `grow_to_structarray!` is a useful building block for `collect`-like functions.
+Combined with [function barriers](https://docs.julialang.org/en/latest/manual/performance-tips/#kernel-functions-1), `append!!` is a useful building block for implementing `collect`-like functions.

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -4,7 +4,7 @@ using Base: tuple_type_cons, tuple_type_head, tuple_type_tail, tail
 using PooledArrays: PooledArray
 
 export StructArray, StructVector, LazyRow, LazyRows
-export collect_structarray, collect_to_structarray!, fieldarrays
+export collect_structarray, fieldarrays
 export replace_storage
 
 include("interface.jl")

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -4,7 +4,7 @@ using Base: tuple_type_cons, tuple_type_head, tuple_type_tail, tail
 using PooledArrays: PooledArray
 
 export StructArray, StructVector, LazyRow, LazyRows
-export collect_structarray, fieldarrays
+export collect_structarray, collect_to_structarray!, fieldarrays
 export replace_storage
 
 include("interface.jl")

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -59,11 +59,11 @@ function collect_structarray(itr, elem, sz::Union{Base.HasShape, Base.HasLength}
     S = typeof(el)
     dest = initializer(S, (length(itr),))
     dest[1] = el
-    v = collect_to_structarray!(dest, itr, 2, i)
+    v = _collect_to_structarray!(dest, itr, 2, i)
     _reshape(v, itr, sz)
 end
 
-function collect_to_structarray!(dest::AbstractArray, itr, offs, st)
+function _collect_to_structarray!(dest::AbstractArray, itr, offs, st)
     # collect to dest array, checking the type of each result. if a result does not
     # match, widen the result type and re-dispatch.
     i = offs
@@ -77,7 +77,7 @@ function collect_to_structarray!(dest::AbstractArray, itr, offs, st)
         else
             new = widenstructarray(dest, i, el)
             @inbounds new[i] = el
-            return collect_to_structarray!(new, itr, i+1, st)
+            return _collect_to_structarray!(new, itr, i+1, st)
         end
     end
     return dest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using StructArrays
-using StructArrays: staticschema, iscompatible, _promote_typejoin
+using StructArrays: staticschema, iscompatible, _promote_typejoin, append!!
 using OffsetArrays: OffsetArray
 import Tables, PooledArrays, WeakRefStrings
 using Test
@@ -375,7 +375,7 @@ collect_structarray_rec(t) = collect_structarray(t, initializer = initializer)
     el, st = iterate(itr)
     dest = initializer(typeof(el), (3,))
     dest[1] = el
-    @inferred StructArrays._collect_to_structarray!(dest, itr, 2, st)
+    @inferred StructArrays.collect_to_structarray!(dest, itr, 2, st)
 
     v = [(a = 1, b = 2), (a = 1.2, b = 3)]
     @test collect_structarray_rec(v) == StructArray((a = [1, 1.2], b = Int[2, 3]))
@@ -647,7 +647,7 @@ end
     @test str == "StructArray(::Array{Int64,1}, ::Array{Int64,1})"
 end
 
-@testset "collect_to_structarray!" begin
+@testset "append!!" begin
     dest_examples = [
         ("mutate", StructVector(a = [1], b = [2])),
         ("widen", StructVector(a = [1], b = [nothing])),
@@ -664,6 +664,6 @@ end
     @testset "$destlabel $itrlabel" for (destlabel, dest) in dest_examples,
                                         (itrlabel, makeitr) in itr_examples
 
-        @test vcat(dest, StructVector(makeitr())) == collect_to_structarray!(copy(dest), makeitr())
+        @test vcat(dest, StructVector(makeitr())) == append!!(copy(dest), makeitr())
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -375,7 +375,7 @@ collect_structarray_rec(t) = collect_structarray(t, initializer = initializer)
     el, st = iterate(itr)
     dest = initializer(typeof(el), (3,))
     dest[1] = el
-    @inferred StructArrays.collect_to_structarray!(dest, itr, 2, st)
+    @inferred StructArrays._collect_to_structarray!(dest, itr, 2, st)
 
     v = [(a = 1, b = 2), (a = 1.2, b = 3)]
     @test collect_structarray_rec(v) == StructArray((a = [1, 1.2], b = Int[2, 3]))


### PR DESCRIPTION
I'm trying to create a uniform interface (e.g., [`BangBang.append!!`](https://tkf.github.io/BangBang.jl/dev/#BangBang.append!!-Tuple{Any,Any})) for mutate-or-widen style manipulations of various container types.  This is very useful for implementing push-oriented data manipulation API like [`Transducers.copy`](https://tkf.github.io/Transducers.jl/dev/manual/#Base.copy).

As `StructArrays` already has `grow_to_structarray!`, it would be nice if I can use it as-is.  Are you OK with providing it as a public API?  This PR adds documentation in README to explicitly document it as a public API.
