### PR TITLE
Support collecting to offset arrays

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -54,12 +54,13 @@ function _collect_structarray(itr, elem, len; initializer = default_initializer)
     el, st = elem
     S = typeof(el)
     dest = initializer(S, (len,))
-    @inbounds dest[1] = el
+    offs = firstindex(dest)
+    @inbounds dest[offs] = el
     return _collect_structarray!(dest, itr, st, Base.IteratorSize(itr))
 end
 
 function _collect_structarray!(dest, itr, st, ::Union{Base.HasShape, Base.HasLength})
-    v = collect_to_structarray!(dest, itr, 2, st)
+    v = collect_to_structarray!(dest, itr, firstindex(dest) + 1, st)
     return _reshape(v, itr)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -528,6 +528,23 @@ end
     @test sa isa StructArray
     @test axes(sa) == (-2:7,)
     @test sa.a == fill(1, -2:7)
+
+    zero_origin(T, d) = OffsetArray{T}(undef, map(n -> 0:n-1, d))
+    sa = collect_structarray(
+        [(a = 1,), (a = 2,), (a = 3,)],
+        initializer = StructArrays.StructArrayInitializer(t -> false, zero_origin),
+    )
+    @test sa isa StructArray
+    @test collect(sa.a) == 1:3
+    @test_broken sa.a isa OffsetArray
+
+    sa = collect_structarray(
+        (x for x in [(a = 1,), (a = 2,), (a = 3,)] if true),
+        initializer = StructArrays.StructArrayInitializer(t -> false, zero_origin),
+    )
+    @test sa isa StructArray
+    @test collect(sa.a) == 1:3
+    @test sa.a isa OffsetArray
 end
 
 @testset "hasfields" begin


### PR DESCRIPTION
This is something I noticed while writing #97.  Not sure if you need this but I guess it's easier to fix than checking `has_offset_axes` and giving a good error message.