### PR TITLE
add optimized append

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -161,7 +161,7 @@ _append!!(dest::AbstractVector, itr, ::Base.SizeUnknown) =
 
 # Optimized version when element collection is an `AbstractVector`
 # This only works for julia 1.3 or greater, which has `append!` for `AbstractVector`
-@static if VERSION < v"1.3.0"
+@static if VERSION ≥ v"1.3.0"
     function append!!(dest::V, v::AbstractVector{T}) where {V<:AbstractVector, T}
         new = iscompatible(T, V) ? dest : widen_from_type(dest, length(dest) + 1, T)
         return append!(new, v)

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -169,12 +169,12 @@ Base.@propagate_inbounds function Base.setindex!(s::StructArray{<:Any, <:Any, <:
     s
 end
 
-function Base.push!(s::StructArray, vals)
+function Base.push!(s::StructVector, vals)
     foreachfield(push!, s, vals)
     return s
 end
 
-function Base.append!(s::StructArray, vals)
+function Base.append!(s::StructVector, vals::StructVector)
     foreachfield(append!, s, vals)
     return s
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -681,6 +681,7 @@ end
     itr = [(a = 1, b = 2), (a = 1, b = 2), (a = 1, b = 12)]
     itr_examples = [
         ("HasLength", () -> itr),
+        ("StructArray", () -> StructArray(itr)),
         ("SizeUnknown", () -> (x for x in itr if isodd(x.a))),
         # Broken due to https://github.com/JuliaArrays/StructArrays.jl/issues/100:
         # ("empty", (x for x in itr if false)),


### PR DESCRIPTION
This fixes the dispatch for `push!` and `append!` and adds an optimized `append!!` method when the iterator being appended is an `AbstractVector`.

TODO:

- [x] Add tests.