### PR TITLE
Use Tables.isrowtable (Tables v1.0 API)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 DataAPI = "1"
-Tables = "0.2"
+Tables = "1"
 julia = "1"
 
 [extras]

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,10 +1,8 @@
 using Tables: Tables
 
-Tables.istable(::Type{<:StructVector}) = true
-Tables.rowaccess(::Type{<:StructVector}) = true
-Tables.columnaccess(::Type{<:StructVector}) = true
+Tables.isrowtable(::Type{<:StructVector}) = true
 
-Tables.rows(s::StructVector) = s
+Tables.columnaccess(::Type{<:StructVector}) = true
 Tables.columns(s::StructVector) = fieldarrays(s)
 
 Tables.schema(s::StructVector) = Tables.Schema(staticschema(eltype(s)))


### PR DESCRIPTION
This PR simplifies and improves Tables.jl integration by using `Tables.isrowtable` introduced by https://github.com/JuliaData/Tables.jl/issues/134. This patch requires Tables v1.0 which is not released yet. So I'm posting it as a WIP PR for now.

This PR combined with https://github.com/JuliaData/TypedTables.jl/pull/57 makes `append!(::TypedTables.Table, ::StructArray)` work column-by-column as an optimization.