### PR TITLE
RFC: Add append!(::StructVector, iterator::Any) using Tables.isrowtable

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -6,3 +6,19 @@ Tables.columnaccess(::Type{<:StructVector}) = true
 Tables.columns(s::StructVector) = fieldarrays(s)
 
 Tables.schema(s::StructVector) = Tables.Schema(staticschema(eltype(s)))
+
+function Base.append!(s::StructVector, rows)
+    if Tables.isrowtable(rows) && Tables.columnaccess(rows)
+        # Input `rows` is a container of rows _and_ satisfies column
+        # table interface.  Thus, we can add the input column-by-column.
+        table = Tables.columns(rows)
+        nt = foldl(Tables.columnnames(table); init = NamedTuple()) do nt, name
+            (; nt..., name => Tables.getcolumn(table, name))
+        end
+        return append!(s, StructArray(nt))
+    else
+        # Otherwise, fallback to a generic implementation expecting
+        # that `rows` is an iterator:
+        return foldl(push!, rows; init=s)
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -134,3 +134,16 @@ hasfields(::Type{<:NTuple{N, Any}}) where {N} = true
 hasfields(::Type{<:NamedTuple{names}}) where {names} = true
 hasfields(::Type{T}) where {T} = !isabstracttype(T)
 hasfields(::Union) = false
+
+_setdiff(a, b) = setdiff(a, b)
+
+@inline _setdiff(::Tuple{}, ::Tuple{}) = ()
+@inline _setdiff(::Tuple{}, ::Tuple) = ()
+@inline _setdiff(a::Tuple, ::Tuple{}) = a
+@inline _setdiff(a::Tuple, b::Tuple) = _setdiff(_exclude(a, b[1]), Base.tail(b))
+@inline _exclude(a, b) = foldl((ys, x) -> x == b ? ys : (ys..., x), a; init = ())
+
+# _foreach(f, xs) = foreach(f, xs)
+_foreach(f, xs::Tuple) = foldl((_, x) -> (f(x); nothing), xs; init = nothing)
+# Note `foreach` is not optimized for tuples yet.
+# See: https://github.com/JuliaLang/julia/pull/31901

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -339,6 +339,13 @@ end
     @test Tables.rowaccess(typeof(s))
     @test Tables.columnaccess(s)
     @test Tables.columnaccess(typeof(s))
+    @test append!(StructArray([1im]), [(re = 111, im = 222)]) ==
+        StructArray([1im, 111 + 222im])
+    @test append!(StructArray([1im]), (x for x in [(re = 111, im = 222)])) ==
+        StructArray([1im, 111 + 222im])
+    # Testing integer column "names":
+    @test invoke(append!, Tuple{StructVector,Any}, StructArray(([0],)), StructArray(([1],))) ==
+        StructArray(([0, 1],))
 end
 
 struct S


### PR DESCRIPTION
This PR implements:

1. A generic `append!` so that any "row iterator" can be appended to a struct array.
2. An optimized path based on `Tables.isrowtable`.

This is the same API implemented in https://github.com/JuliaData/TypedTables.jl/pull/57. Since this is a PR on top of #116, I'm posting it as a draft.

I'll add some tests if adding this API is OK.