### PR TITLE
switch to getcolumn and support tables in ND StructArray

### DIFF
--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -1,6 +1,7 @@
 module StructArrays
 
 using Base: tuple_type_cons, tuple_type_head, tuple_type_tail, tail
+using Tables: getcolumn, Tables
 
 export StructArray, StructVector, LazyRow, LazyRows
 export collect_structarray, fieldarrays

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -15,6 +15,7 @@ for typ in [:Symbol, :Int]
     end
 end
 Base.propertynames(c::LazyRow) = propertynames(getfield(c, 1))
+Tables.getcolumn(s::LazyRow, i::Int) = getproperty(s, i)
 
 function Base.show(io::IO, c::LazyRow)
     print(io, "LazyRow")
@@ -34,6 +35,7 @@ end
 Base.parent(v::LazyRows) = getfield(v, 1)
 fieldarrays(v::LazyRows) = fieldarrays(parent(v))
 
+Tables.getcolumn(s::LazyRow, i::Int) = getproperty(s, i)
 Base.getproperty(s::LazyRows, key::Symbol) = getproperty(parent(s), key)
 Base.getproperty(s::LazyRows, key::Int) = getproperty(parent(s), key)
 Base.propertynames(c::LazyRows) = propertynames(parent(c))

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -15,11 +15,12 @@ for typ in [:Symbol, :Int]
     end
 end
 Base.propertynames(c::LazyRow) = propertynames(getfield(c, 1))
-Tables.getcolumn(s::LazyRow, i::Int) = getproperty(s, i)
 
 function Base.show(io::IO, c::LazyRow)
     print(io, "LazyRow")
-    show(io, to_tup(c))
+    columns, index = getfield(c, 1), getfield(c, 2)
+    tup = StructArray(fieldarrays(columns))[index]
+    show(io, tup)
 end
 
 staticschema(::Type{<:LazyRow{T}}) where {T} = staticschema(T)
@@ -35,7 +36,6 @@ end
 Base.parent(v::LazyRows) = getfield(v, 1)
 fieldarrays(v::LazyRows) = fieldarrays(parent(v))
 
-Tables.getcolumn(s::LazyRow, i::Int) = getproperty(s, i)
 Base.getproperty(s::LazyRows, key::Symbol) = getproperty(parent(s), key)
 Base.getproperty(s::LazyRows, key::Int) = getproperty(parent(s), key)
 Base.propertynames(c::LazyRows) = propertynames(parent(c))

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,11 +1,11 @@
-using Tables: Tables
+Tables.isrowtable(::Type{<:StructArray}) = true
 
-Tables.isrowtable(::Type{<:StructVector}) = true
+Tables.columnaccess(::Type{<:StructArray}) = true
+Tables.columns(s::StructArray) = s
 
-Tables.columnaccess(::Type{<:StructVector}) = true
-Tables.columns(s::StructVector) = fieldarrays(s)
+Tables.getcolumn(s::StructArray, i::Int) = getproperty(s, i)
 
-Tables.schema(s::StructVector) = Tables.Schema(staticschema(eltype(s)))
+Tables.schema(s::StructArray) = Tables.Schema(staticschema(eltype(s)))
 
 function Base.append!(s::StructVector, rows)
     if Tables.isrowtable(rows) && Tables.columnaccess(rows)
@@ -14,9 +14,7 @@ function Base.append!(s::StructVector, rows)
         table = Tables.columns(rows)
         isempty(_setdiff(propertynames(s), Tables.columnnames(rows))) ||
             _invalid_columns_error(s, rows)
-        _foreach(propertynames(s)) do name
-            append!(getproperty(s, name), Tables.getcolumn(table, name))
-        end
+        foreachfield(append!, s, table)
         return s
     else
         # Otherwise, fallback to a generic implementation expecting

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,10 +1,8 @@
 Tables.isrowtable(::Type{<:StructArray}) = true
 
 Tables.columnaccess(::Type{<:StructArray}) = true
-Tables.columns(s::StructArray) = s
-
+Tables.columns(s::StructArray) = fieldarrays(s)
 Tables.getcolumn(s::StructArray, i::Int) = getproperty(s, i)
-
 Tables.schema(s::StructArray) = Tables.Schema(staticschema(eltype(s)))
 
 function Base.append!(s::StructVector, rows)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -115,13 +115,6 @@ function replace_storage(f, s::StructArray{T}) where T
     StructArray{T}(newcols)
 end
 
-to_tup(c::T) where {T} = to_tup(c, fieldnames(staticschema(T)))
-function to_tup(c, fields::NTuple{N, Symbol}) where N
-    t = ntuple(i -> getproperty(c, fields[i]), N)
-    return NamedTuple{fields}(t)
-end
-to_tup(c, fields::NTuple{N, Int}) where {N} = ntuple(i -> getcolumn(c, fields[i]), N)
-
 astuple(::Type{NamedTuple{names, types}}) where {names, types} = types
 astuple(::Type{T}) where {T<:Tuple} = T
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -336,6 +336,10 @@ end
     @test Tables.rowaccess(typeof(s))
     @test Tables.columnaccess(s)
     @test Tables.columnaccess(typeof(s))
+    @test Tables.getcolumn(s, 1) == [1]
+    @test Tables.getcolumn(s, :a) == [1]
+    @test Tables.getcolumn(s, 2) == ["test"]
+    @test Tables.getcolumn(s, :b) == ["test"]
     @test append!(StructArray([1im]), [(re = 111, im = 222)]) ==
         StructArray([1im, 111 + 222im])
     @test append!(StructArray([1im]), (x for x in [(re = 111, im = 222)])) ==

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -626,11 +626,11 @@ end
     rows = LazyRows(s)
     @test IndexStyle(rows) isa IndexLinear
     @test IndexStyle(typeof(rows)) isa IndexLinear
-    @test all(t -> StructArrays._getproperty(t, 1) >= 0, s)
+    @test all(t -> Tables.getcolumn(t, 1) >= 0, s)
     @test all(t -> getproperty(t, 1) >= 0, rows)
     setproperty!(rows[13], 1, -12)
     setproperty!(rows[13], 2, 0)
-    @test !all(t -> StructArrays._getproperty(t, 1) >= 0, s)
+    @test !all(t -> Tables.getcolumn(t, 1) >= 0, s)
     @test !all(t -> getproperty(t, 1) >= 0, rows)
 
     io = IOBuffer()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,11 +318,6 @@ cols_infer() = StructArray(([1, 2], [1.2, 2.3]))
     @inferred cols_infer()
 end
 
-@testset "to_(named)tuple" begin
-    @test StructArrays.to_tup((1, 2, 3)) == (1, 2, 3)
-    @test StructArrays.to_tup(2 + 3im) == (re = 2, im = 3)
-end
-
 @testset "propertynames" begin
     a = StructArray{ComplexF64}((Float64[], Float64[]))
     @test sort(collect(propertynames(a))) == [:im, :re]


### PR DESCRIPTION
Now `foreachfield` relies on `Tables.getcolumn`.

Multidimensional `StructArray` are also treated as tables.

TODO

- [ ] Fully support Tables interface for `LazyRows` as well? (left for later PR)