### PR TITLE
Make StructArrays broadcast aware

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -244,5 +244,8 @@ combine_style_types(s::BroadcastStyle) = s
 Base.@pure cst(::Type{SA}) where SA = combine_style_types(array_types(SA).parameters...)
 
 BroadcastStyle(::Type{SA}) where SA<:StructArray = StructArrayStyle{typeof(cst(SA))}()
+
 Base.similar(bc::Broadcasted{StructArrayStyle{S}}, ::Type{ElType}) where {S<:DefaultArrayStyle,N,ElType} =
     isstructtype(ElType) ? similar(StructArray{ElType}, axes(bc)) : similar(Array{ElType}, axes(bc))
+Base.similar(bc::Broadcasted{StructArrayStyle{S}}, ::Type{ElType}) where {S<:ArrayStyle{A},N,ElType} where A =
+    similar(A{ElType}, axes(bc))

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -247,5 +247,3 @@ BroadcastStyle(::Type{SA}) where SA<:StructArray = StructArrayStyle{typeof(cst(S
 
 Base.similar(bc::Broadcasted{StructArrayStyle{S}}, ::Type{ElType}) where {S<:DefaultArrayStyle,N,ElType} =
     isstructtype(ElType) ? similar(StructArray{ElType}, axes(bc)) : similar(Array{ElType}, axes(bc))
-Base.similar(bc::Broadcasted{StructArrayStyle{S}}, ::Type{ElType}) where {S<:ArrayStyle{A},N,ElType} where A =
-    similar(A{ElType}, axes(bc))

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -27,6 +27,10 @@ end
 
 index_type(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = I
 
+array_types(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = array_types(C)
+array_types(::Type{NamedTuple{names, types}}) where {names, types} = types
+array_types(::Type{TT}) where {TT<:Tuple} = TT
+
 function StructArray{T}(c::C) where {T, C<:Tup}
     cols = strip_params(staticschema(T))(c)
     N = isempty(cols) ? 1 : ndims(cols[1])
@@ -227,8 +231,18 @@ function Base.showarg(io::IO, s::StructArray{T}, toplevel) where T
 end
 
 # broadcast
-import Base.Broadcast: BroadcastStyle, ArrayStyle, Broadcasted
+import Base.Broadcast: BroadcastStyle, ArrayStyle, AbstractArrayStyle, Broadcasted, DefaultArrayStyle
 
-BroadcastStyle(::Type{<:StructArray}) = ArrayStyle{StructArray}()
-Base.similar(bc::Broadcasted{ArrayStyle{StructArray}}, ::Type{ElType}) where {N,ElType} =
-    similar(StructArray{ElType}, axes(bc))
+struct StructArrayStyle{Style} <: AbstractArrayStyle{Any} end
+
+@inline combine_style_types(::Type{A}, args...) where A<:AbstractArray =
+    combine_style_types(BroadcastStyle(A), args...)
+@inline combine_style_types(s::BroadcastStyle, ::Type{A}, args...) where A<:AbstractArray =
+    combine_style_types(Broadcast.result_style(s, BroadcastStyle(A)), args...)
+combine_style_types(s::BroadcastStyle) = s
+
+Base.@pure cst(::Type{SA}) where SA = combine_style_types(array_types(SA).parameters...)
+
+BroadcastStyle(::Type{SA}) where SA<:StructArray = StructArrayStyle{typeof(cst(SA))}()
+Base.similar(bc::Broadcasted{StructArrayStyle{S}}, ::Type{ElType}) where {S<:DefaultArrayStyle,N,ElType} =
+    isstructtype(ElType) ? similar(StructArray{ElType}, axes(bc)) : similar(Array{ElType}, axes(bc))

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -22,14 +22,14 @@ index_type(::Type{NamedTuple{names, types}}) where {names, types} = index_type(t
 index_type(::Type{Tuple{}}) = Int
 function index_type(::Type{T}) where {T<:Tuple}
     S, U = tuple_type_head(T), tuple_type_tail(T)
-    IndexStyle(S) isa IndexCartesian ? CartesianIndex{ndims(S)} : index_type(U) 
+    IndexStyle(S) isa IndexCartesian ? CartesianIndex{ndims(S)} : index_type(U)
 end
 
 index_type(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = I
 
 function StructArray{T}(c::C) where {T, C<:Tup}
     cols = strip_params(staticschema(T))(c)
-    N = isempty(cols) ? 1 : ndims(cols[1]) 
+    N = isempty(cols) ? 1 : ndims(cols[1])
     StructArray{T, N, typeof(cols)}(cols)
 end
 
@@ -225,3 +225,10 @@ function Base.showarg(io::IO, s::StructArray{T}, toplevel) where T
     showfields(io, Tuple(fieldarrays(s)))
     toplevel && print(io, " with eltype ", T)
 end
+
+# broadcast
+import Base.Broadcast: BroadcastStyle, ArrayStyle, Broadcasted
+
+BroadcastStyle(::Type{<:StructArray}) = ArrayStyle{StructArray}()
+Base.similar(bc::Broadcasted{ArrayStyle{StructArray}}, ::Type{ElType}) where {N,ElType} =
+    similar(StructArray{ElType}, axes(bc))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -741,7 +741,5 @@ Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{MyArray}}, ::Type{El
     @test s .+ r == StructArray{ComplexF64}((s.re .+ r, s.im))
 
     s = StructArray{ComplexF64}((MyArray(rand(2,2)), MyArray(rand(2,2))))
-    @test isa(@inferred(s .+ s), MyArray)
-    @test real.((s .+ s)) == 2*s.re
-    @test imag.((s .+ s)) == 2*s.im
+    @test_throws MethodError s .+ s
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -714,3 +714,8 @@ Adapt.adapt_storage(::ArrayConverter, xs::AbstractArray) = convert(Array, xs)
     @test t.b.c isa Array
     @test t.b.d isa Array
 end
+
+@testset "broadcast" begin
+    s = StructArray{ComplexF64}((rand(2,2), rand(2,2)))
+    @test isa(s .+ s, StructArray)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -717,5 +717,14 @@ end
 
 @testset "broadcast" begin
     s = StructArray{ComplexF64}((rand(2,2), rand(2,2)))
-    @test isa(s .+ s, StructArray)
+    @test isa(@inferred(s .+ s), StructArray)
+    @test (s .+ s).re == 2*s.re
+    @test (s .+ s).im == 2*s.im
+    @test isa(@inferred(broadcast(t->1, s)), Array)
+    @test all(x->x==1, broadcast(t->1, s))
+    @test isa(@inferred(s .+ 1), StructArray)
+    @test s .+ 1 == StructArray{ComplexF64}((s.re .+ 1, s.im))
+    r = rand(2,2)
+    @test isa(@inferred(s .+ r), StructArray)
+    @test s .+ r == StructArray{ComplexF64}((s.re .+ r, s.im))
 end


### PR DESCRIPTION
Continues #90. This is more conservative, returning a `StructArray` only if none of the other participating arrays (including the ones wrapped in the StructArray) have specialized broadcast behavior. One could add binary `BroadcastStyle` rules to control behavior in other cases, but it seems best to wait until there's a real-world use case.