### PR TITLE
Fix allocations for LazyRow

### DIFF
--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -5,12 +5,11 @@ end
 
 for typ in [:Symbol, :Int]
     @eval begin
-        Base.@propagate_inbounds function Base.getproperty(c::LazyRow, nm::$typ)
+        @inline Base.@propagate_inbounds function Base.getproperty(c::LazyRow, nm::$typ)
             return getproperty(getfield(c, 1), nm)[getfield(c, 2)]
         end
-        Base.@propagate_inbounds function Base.setproperty!(c::LazyRow, nm::$typ, val)
+        @inline Base.@propagate_inbounds function Base.setproperty!(c::LazyRow, nm::$typ, val)
             getproperty(getfield(c, 1), nm)[getfield(c, 2)] = val
-            return
         end
     end
 end


### PR DESCRIPTION
This PR fixes allocations for the LazyRow type by inlining the getproperty and setproperty! functions and removing the return call (see #152 and https://discourse.julialang.org/t/understanding-and-avoiding-allocations-with-structarrays).
