### PR TITLE
add StructArray constructor from slices of an existing array

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,6 +15,7 @@ StructArray
 
 ```@docs
 StructArray(tup::Union{Tuple,NamedTuple})
+StructArray(::AbstractArray)
 StructArray(::Base.UndefInitializer, sz::Dims)
 StructArray(v)
 collect_structarray

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -135,6 +135,7 @@ julia> StructArray{Complex{Float64}}(X; dims=2)
  3.0 + 4.0im
 ```
 """
+StructArray(A::AbstractArray; dims)
 function StructArray{T}(A::AbstractArray; dims) where {T}
     slices = Iterators.Stateful(eachslice(A; dims=dims))
     buildfromslices(T, eltype(A), slices)

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -110,10 +110,12 @@ StructVector{T}(args...; kwargs...) where {T} = StructArray{T}(args...; kwargs..
 StructVector(args...; kwargs...) = StructArray(args...; kwargs...)
 
 """
-    StructArray{T}(A::AbstractArray; dims)
+    StructArray{T}(A::AbstractArray; dims, unwrap=FT->FT!=eltype(A))
 
-Construct a `StructArray` from slices of `A` along `dims`. `T` will be
-recursively decomposed to fields of `eltype(A)`.
+Construct a `StructArray` from slices of `A` along `dims`. 
+
+The `unwrap` keyword argument is a function that determines whether to
+recursively convert fields of type `FT` to `StructArray`s.
 
 !!! compat "Julia 1.1"
      This function requires at least Julia 1.1.
@@ -134,19 +136,27 @@ julia> StructArray{Complex{Float64}}(X; dims=2)
  1.0 + 2.0im
  3.0 + 4.0im
 ```
+
+By default, fields will be unwrapped until they match the element type of the array:
+```
+julia> StructArray{Tuple{Float64,Complex{Float64}}}(rand(3,2); dims=1)
+2-element StructArray(view(::Array{Float64,2}, 1, :), StructArray(view(::Array{Float64,2}, 2, :), view(::Array{Float64,2}, 3, :))) with eltype Tuple{Float64,Complex{Float64}}:
+ (0.004767505234193781, 0.27949621887414566 + 0.9039320635041561im)
+ (0.41853472213051335, 0.5760165160827859 + 0.9782723869433818im)
+```
 """
-StructArray(A::AbstractArray; dims)
-function StructArray{T}(A::AbstractArray; dims) where {T}
+StructArray(A::AbstractArray; dims, unwrap)
+function StructArray{T}(A::AbstractArray; dims, unwrap=FT->FT!=eltype(A)) where {T}
     slices = Iterators.Stateful(eachslice(A; dims=dims))
-    buildfromslices(T, eltype(A), slices)
+    buildfromslices(T, unwrap, slices)
 end
-function buildfromslices(::Type{T}, ::Type{AT}, slices) where {T,AT}
-    if T == AT
-        return popfirst!(slices)
-    else
+function buildfromslices(::Type{T}, unwrap::F, slices) where {T,F}
+    if unwrap(T)
         buildfromschema(T) do FT
-            buildfromslices(FT, AT, slices)
+            buildfromslices(FT, unwrap, slices)
         end
+    else
+        return popfirst!(slices)
     end
 end
 

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -112,9 +112,11 @@ StructVector(args...; kwargs...) = StructArray(args...; kwargs...)
 """
     StructArray{T}(A::AbstractArray; dims)
 
-Construct a `StructArray` from slices of `A` along `dims`.
+Construct a `StructArray` from slices of `A` along `dims`. `T` will be
+recursively decomposed to fields of `eltype(A)`.
 
-`T` will be recursively decomposed to fields of `eltype(A)`.
+!!! compat "Julia 1.1"
+     This function requires at least Julia 1.1.
 
 ```julia-repl
 julia> X = [1.0 2.0; 3.0 4.0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,6 +242,16 @@ end
     @test getproperty(t, 2) == [3.0, 2.0]
 end
 
+@testset "constructor from slices" begin
+    X = [1.0 2.0; 3.0 4.0]
+    @test StructArray{Complex{Float64}}(X; dims=1) == [Complex(1.0,3.0), Complex(2.0,4.0)]
+    @test StructArray{Complex{Float64}}(X; dims=2) == [Complex(1.0,2.0), Complex(3.0,4.0)]
+
+    X = [1.0 2.0; 3.0 4.0; 5.0 6.0]
+    @test StructArray{Tuple{Float64,Complex{Float64}}}(X; dims=1) == [(1.0,Complex(3.0,5.0)), (2.0, Complex(4.0,6.0))]
+end
+
+
 struct A
     x::Int
     y::Int

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -243,12 +243,14 @@ end
 end
 
 @testset "constructor from slices" begin
-    X = [1.0 2.0; 3.0 4.0]
-    @test StructArray{Complex{Float64}}(X; dims=1) == [Complex(1.0,3.0), Complex(2.0,4.0)]
-    @test StructArray{Complex{Float64}}(X; dims=2) == [Complex(1.0,2.0), Complex(3.0,4.0)]
+    if VERSION >= v"1.1"
+        X = [1.0 2.0; 3.0 4.0]
+        @test StructArray{Complex{Float64}}(X; dims=1) == [Complex(1.0,3.0), Complex(2.0,4.0)]
+        @test StructArray{Complex{Float64}}(X; dims=2) == [Complex(1.0,2.0), Complex(3.0,4.0)]
 
-    X = [1.0 2.0; 3.0 4.0; 5.0 6.0]
-    @test StructArray{Tuple{Float64,Complex{Float64}}}(X; dims=1) == [(1.0,Complex(3.0,5.0)), (2.0, Complex(4.0,6.0))]
+        X = [1.0 2.0; 3.0 4.0; 5.0 6.0]
+        @test StructArray{Tuple{Float64,Complex{Float64}}}(X; dims=1) == [(1.0,Complex(3.0,5.0)), (2.0, Complex(4.0,6.0))]
+    end
 end
 
 


### PR DESCRIPTION
So we can use `StructArrays` as a nicer `reinterpret`, and also allow for array-of-structs-of-array layouts (by specifying a `dims` other than 1).