### PR TITLE
add some specialization hints for function arguments

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -4,7 +4,7 @@ struct StructArrayInitializer{F, G}
     unwrap::F
     arrayof::G
 end
-StructArrayInitializer(unwrap = t->false) = StructArrayInitializer(unwrap, arrayof)
+StructArrayInitializer(unwrap::F = alwaysfalse) where {F} = StructArrayInitializer(unwrap, arrayof)
 
 const default_initializer = StructArrayInitializer()
 
@@ -17,7 +17,7 @@ struct ArrayInitializer{F, G}
     unwrap::F
     arrayof::G
 end
-ArrayInitializer(unwrap = t->false) = ArrayInitializer(unwrap, arrayof)
+ArrayInitializer(unwrap::F = alwaysfalse) where {F} = ArrayInitializer(unwrap, arrayof)
 
 (s::ArrayInitializer)(S, d) = s.unwrap(S) ? buildfromschema(typ -> s(typ, d), S) : s.arrayof(S, d)
 

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -113,7 +113,7 @@ function Base.IndexStyle(::Type{S}) where {S<:StructArray}
     index_type(S) === Int ? IndexLinear() : IndexCartesian()
 end
 
-function _undef_array(::Type{T}, sz; unwrap = t -> false) where {T}
+function _undef_array(::Type{T}, sz; unwrap::F = alwaysfalse) where {T, F}
     if unwrap(T)
         return StructArray{T}(undef, sz; unwrap = unwrap)
     else
@@ -121,7 +121,7 @@ function _undef_array(::Type{T}, sz; unwrap = t -> false) where {T}
     end
 end
 
-function _similar(v::AbstractArray, ::Type{Z}; unwrap = t -> false) where {Z}
+function _similar(v::AbstractArray, ::Type{Z}; unwrap::F = alwaysfalse) where {Z, F}
     if unwrap(Z)
         return buildfromschema(typ -> _similar(v, typ; unwrap = unwrap), Z)
     else
@@ -149,12 +149,12 @@ julia> StructArray{ComplexF64}(undef, (2,3))
 """
 StructArray(::Base.UndefInitializer, sz::Dims)
 
-function StructArray{T}(::Base.UndefInitializer, sz::Dims; unwrap = t -> false) where {T}
+function StructArray{T}(::Base.UndefInitializer, sz::Dims; unwrap::F = alwaysfalse) where {T, F}
     buildfromschema(typ -> _undef_array(typ, sz; unwrap = unwrap), T)
 end
-StructArray{T}(u::Base.UndefInitializer, d::Integer...; unwrap = t -> false) where {T} = StructArray{T}(u, convert(Dims, d); unwrap = unwrap)
+StructArray{T}(u::Base.UndefInitializer, d::Integer...; unwrap::F = alwaysfalse) where {T, F} = StructArray{T}(u, convert(Dims, d); unwrap = unwrap)
 
-function similar_structarray(v::AbstractArray, ::Type{Z}; unwrap = t -> false) where {Z}
+function similar_structarray(v::AbstractArray, ::Type{Z}; unwrap::F = alwaysfalse) where {Z, F}
     buildfromschema(typ -> _similar(v, typ; unwrap = unwrap), Z)
 end
 
@@ -203,11 +203,11 @@ julia> StructArray((1, Complex(i, j)) for i = 1:3, j = 2:4; unwrap = T -> !(T<:R
  (1, 3+2im)  (1, 3+3im)  (1, 3+4im)
 ```
 """
-function StructArray(v; unwrap = t -> false)::StructArray
+function StructArray(v; unwrap::F = alwaysfalse)::StructArray where {F}
     collect_structarray(v; initializer = StructArrayInitializer(unwrap))
 end
 
-function StructArray(v::AbstractArray{T}; unwrap = t -> false) where {T}
+function StructArray(v::AbstractArray{T}; unwrap::F = alwaysfalse) where {T, F}
     s = similar_structarray(v, T; unwrap = unwrap)
     for i in eachindex(v)
         @inbounds s[i] = v[i]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,7 @@
 eltypes(::Type{T}) where {T} = map_params(eltype, T)
 
+alwaysfalse(t) = false
+
 """
     StructArrays.map_params(f, T)
 
@@ -33,10 +35,10 @@ _map_params(f, ::Type{Tuple{}}) = ()
 function _map_params(f, ::Type{T}) where {T<:Tuple}
     (f(tuple_type_head(T)), _map_params(f, tuple_type_tail(T))...)
 end
-_map_params(f, ::Type{NamedTuple{names, types}}) where {names, types} =
+_map_params(f::F, ::Type{NamedTuple{names, types}}) where {names, types, F} =
     NamedTuple{names}(_map_params(f, types))
 
-buildfromschema(initializer, ::Type{T}) where {T} = buildfromschema(initializer, T, staticschema(T))
+buildfromschema(initializer::F, ::Type{T}) where {T, F} = buildfromschema(initializer, T, staticschema(T))
 
 """
     StructArrays.buildfromschema(initializer, T[, S])
@@ -47,7 +49,7 @@ Construct a [`StructArray{T}`](@ref) with a function `initializer`, using a sche
 
 `S` is a `Tuple` or `NamedTuple` type. The default value is [`staticschema(T)`](@ref).
 """
-function buildfromschema(initializer, ::Type{T}, ::Type{NT}) where {T, NT<:Tup}
+function buildfromschema(initializer::F, ::Type{T}, ::Type{NT}) where {T, NT<:Tup, F}
     nt = _map_params(initializer, NT)
     StructArray{T}(nt)
 end


### PR DESCRIPTION
This improves the performance of the `StructArray` constructor to pretty much match Unzip.jl, and should reduce compilation by sharing the default `false` unwrap function.