### PR TITLE
switch to component interface

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,8 +20,6 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - windows-latest
-          - macos-latest
         arch:
           - x64
     steps:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,10 @@
 
 ### Breaking
 
-- Renamed `fieldarrays` to `components` [#167](https://github.com/JuliaArrays/StructArrays.jl/pull/167)
-- `getproperty` is no longer used to access fields of a struct. It is replaced by `StructArrays.component(x, i)` [#167](https://github.com/JuliaArrays/StructArrays.jl/pull/167)
-- Broadcast on `StructArray`s now returns a `StructArray` [#136](https://github.com/JuliaArrays/StructArrays.jl/pull/136)
+- Renamed `fieldarrays` to `StructArrays.components` [#167](https://github.com/JuliaArrays/StructArrays.jl/pull/167)
+- `getproperty` is no longer used to access fields of a struct. It is replaced by `StructArrays.component(x, i)` [#167](https://github.com/JuliaArrays/StructArrays.jl/pull/167). This is only relevant for structs with custom layout.
 - Inner constructors are bypassed on `getindex` [#145](https://github.com/JuliaArrays/StructArrays.jl/pull/136)
+- Broadcast on `StructArray`s now returns a `StructArray` [#136](https://github.com/JuliaArrays/StructArrays.jl/pull/136)
 
 ## Version 0.4.0
 
@@ -28,4 +28,3 @@
 
 - Added `collect_structarray` function to collect an iterable of structs into a `StructArray` without having to allocate an array of structs
 - `StructArray{T}(undef, dims)` and `StructArray(v::AbstractArray)` now support an `unwrap` keyword argument to specify on which types to do recursive unnesting of array of structs to struct of arrays
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,21 @@
 # NEWS
 
+## Version 0.6.0
+
+### Breaking
+
+- Renamed `fieldarrays` to `components` [#167](https://github.com/JuliaArrays/StructArrays.jl/pull/167)
+- `getproperty` is no longer use to access fields of a struct, and is replaced by `StructArrays.component(x, i)` [#167](https://github.com/JuliaArrays/StructArrays.jl/pull/167)
+- Broadcast on `StructArray`s now returns a `StructArray` [#136](https://github.com/JuliaArrays/StructArrays.jl/pull/136)
+- Inner constructors are bypassed on `getindex` [#145](https://github.com/JuliaArrays/StructArrays.jl/pull/136)
+
 ## Version 0.4.0
 
 ### Breaking
 
 - `fieldarrays` now returns a tuple of arrays for a `StructArray{<:Tuple}`
 - `push!` now only works if the `StructArray` and the element have the same propertynames
-- the special constructor `StructArray(first_col => last_col)` is no longer supported
+- The special constructor `StructArray(first_col => last_col)` is no longer supported
 
 ## Version 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 ### Breaking
 
 - Renamed `fieldarrays` to `components` [#167](https://github.com/JuliaArrays/StructArrays.jl/pull/167)
-- `getproperty` is no longer use to access fields of a struct, and is replaced by `StructArrays.component(x, i)` [#167](https://github.com/JuliaArrays/StructArrays.jl/pull/167)
+- `getproperty` is no longer used to access fields of a struct. It is replaced by `StructArrays.component(x, i)` [#167](https://github.com/JuliaArrays/StructArrays.jl/pull/167)
 - Broadcast on `StructArray`s now returns a `StructArray` [#136](https://github.com/JuliaArrays/StructArrays.jl/pull/136)
 - Inner constructors are bypassed on `getindex` [#145](https://github.com/JuliaArrays/StructArrays.jl/pull/136)
 

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,8 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [targets]
-test = ["Test", "OffsetArrays", "PooledArrays", "WeakRefStrings", "Documenter"]
+test = ["Test", "OffsetArrays", "PooledArrays", "TypedTables", "WeakRefStrings", "Documenter"]

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ julia> map(t -> t.b ^ t.a, LazyRows(t))
 
 ## Advanced: structures with non-standard data layout
 
-StructArrays support structures with custom data layout. The user is required to overload `staticschema` in order to define the custom layout, `_getfield` to access fields of the custom layout, and `createinstance(T, fields...)` to create an instance of type `T` from its custom fields `fields`. In other word, given `x::T`, `createinstance(T, (_getfield(x, f) for f in fieldnames(staticschema(T)))...)` should successfully return an instance of type `T`.
+StructArrays support structures with custom data layout. The user is required to overload `staticschema` in order to define the custom layout, `component` to access fields of the custom layout, and `createinstance(T, fields...)` to create an instance of type `T` from its custom fields `fields`. In other word, given `x::T`, `createinstance(T, (component(x, f) for f in fieldnames(staticschema(T)))...)` should successfully return an instance of type `T`.
 
 Here is an example of a type `MyType` that has as custom fields either its field `data` or fields of its field `rest` (which is a named tuple):
 
@@ -201,7 +201,7 @@ function StructArrays.staticschema(::Type{MyType{T, NamedTuple{names, types}}}) 
     return NamedTuple{(:data, names...), Base.tuple_type_cons(T, types)}
 end
 
-function StructArrays._getfield(m::MyType, key::Symbol)
+function StructArrays.component(m::MyType, key::Symbol)
     return key === :data ? getfield(m, 1) : getfield(getfield(m, 2), key)
 end
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ julia> s.re
  0.680079  0.92407
  0.874437  0.929336
 
-julia> fieldarrays(s) # obtain all field arrays as a named tuple
+julia> components(s) # obtain all field arrays as a named tuple
 (re = [0.680079 0.92407; 0.874437 0.929336], im = [0.625239 0.267358; 0.737254 0.804478])
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ julia> s.re
  0.680079  0.92407
  0.874437  0.929336
 
-julia> components(s) # obtain all field arrays as a named tuple
+julia> StructArrays.components(s) # obtain all field arrays as a named tuple
 (re = [0.680079 0.92407; 0.874437 0.929336], im = [0.625239 0.267358; 0.737254 0.804478])
 ```
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+
+[compat]
+PooledArrays = "1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,7 +38,15 @@ LazyRows
 ```@docs
 StructArrays.append!!
 StructArrays.replace_storage
+```
+
+# Interface
+
+```@docs
 StructArrays.staticschema
+StructArrays._fieldnames
+StructArrays._fieldtypes
+StructArrays._getfield
 StructArrays.createinstance
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,7 +23,7 @@ collect_structarray
 # Accessors
 
 ```@docs
-components
+StructArrays.components
 ```
 
 # Lazy iteration

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,7 +23,7 @@ collect_structarray
 # Accessors
 
 ```@docs
-fieldarrays
+components
 ```
 
 # Lazy iteration

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -44,8 +44,6 @@ StructArrays.replace_storage
 
 ```@docs
 StructArrays.staticschema
-StructArrays._fieldnames
-StructArrays._fieldtypes
 StructArrays._getfield
 StructArrays.createinstance
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -44,7 +44,7 @@ StructArrays.replace_storage
 
 ```@docs
 StructArrays.staticschema
-StructArrays._getfield
+StructArrays.component
 StructArrays.createinstance
 ```
 

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -3,7 +3,7 @@ module StructArrays
 using Base: tuple_type_cons, tuple_type_head, tuple_type_tail, tail
 
 export StructArray, StructVector, LazyRow, LazyRows
-export collect_structarray, fieldarrays
+export collect_structarray, components
 export replace_storage
 
 include("interface.jl")
@@ -18,10 +18,10 @@ include("tables.jl")
 import DataAPI: refarray, refvalue
 using DataAPI: defaultarray
 
-refarray(s::StructArray) = StructArray(map(refarray, fieldarrays(s)))
+refarray(s::StructArray) = StructArray(map(refarray, components(s)))
 
 function refvalue(s::StructArray{T}, v::Tup) where {T}
-    createinstance(T, map(refvalue, fieldarrays(s), v)...)
+    createinstance(T, map(refvalue, components(s), v)...)
 end
 
 # Use Adapt allows for automatic conversion of CPU to GPU StructArrays

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -3,7 +3,7 @@ module StructArrays
 using Base: tuple_type_cons, tuple_type_head, tuple_type_tail, tail
 
 export StructArray, StructVector, LazyRow, LazyRows
-export collect_structarray, components
+export collect_structarray
 export replace_storage
 
 include("interface.jl")

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -113,7 +113,7 @@ function _widenstructarray(dest::StructArray, i, ::Type{T}) where {T}
     sch = hasfields(T) ? staticschema(T) : nothing
     sch !== nothing && fieldnames(sch) == propertynames(dest) || return _widenarray(dest, i, T)
     types = ntuple(x -> fieldtype(sch, x), fieldcount(sch))
-    cols = Tuple(fieldarrays(dest))
+    cols = Tuple(components(dest))
     newcols = map((a, b) -> _widenstructarray(a, i, b), cols, types)
     return StructArray{T}(newcols)
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,14 +1,30 @@
 const Tup = Union{Tuple, NamedTuple}
 const EmptyTup = Union{Tuple{}, NamedTuple{(), Tuple{}}}
 
+"""
+    StructArrayys._fieldnames(T)
+
+Default to `fieldnames`. It is used to compute [`StructArrays.staticschema`](@ref).
+"""
 @generated function _fieldnames(::Type{T}) where {T}
     return Expr(:tuple, [QuoteNode(f) for f in fieldnames(T)]...)
 end
 
+"""
+    StructArrayys._fieldtypes(T)
+
+Default to `fieldtypes`. It is used to compute [`StructArrays.staticschema`](@ref).
+"""
 @generated function _fieldtypes(::Type{T}) where {T}
     return Expr(:curly, :Tuple, [Expr(:call, :fieldtype, :T, i) for i in 1:fieldcount(T)]...)
 end
 
+"""
+    StructArrayys._getfield(x, i)
+
+Default to `getfield`. It should be overloaded for custom types with a custom
+schema. See [`StructArrays.staticschema`](@ref).
+"""
 _getfield(x, i) = getfield(x, i)
 
 """
@@ -18,8 +34,9 @@ The default schema for an element type `T`. A schema is a `Tuple` or
 `NamedTuple` type containing the necessary fields to construct `T`. By default,
 this will have fields with the same names and types as `T`.
 
-This can be overloaded for custom types if required, in which case
-[`StructArrays.createinstance`](@ref) should also be defined.
+To have a custom schema for custom types, overload [`StructArrays._fieldnames`](@ref)
+and [`StructArrays._fieldtypes`](@ref). In that case, [`StructArrays._getfield`](@ref)
+and [`StructArrays.createinstance`](@ref) should also be defined.
 
 ```julia-repl
 julia> StructArrays.staticschema(Complex{Float64})

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,12 +2,12 @@ const Tup = Union{Tuple, NamedTuple}
 const EmptyTup = Union{Tuple{}, NamedTuple{(), Tuple{}}}
 
 """
-    StructArrayys._getfield(x, i)
+    StructArrayys.component(x, i)
 
 Default to `getfield`. It should be overloaded for custom types with a custom
 schema. See [`StructArrays.staticschema`](@ref).
 """
-_getfield(x, i) = getfield(x, i)
+component(x, i) = getfield(x, i)
 
 """
     StructArrays.staticschema(T)
@@ -17,7 +17,7 @@ The default schema for an element type `T`. A schema is a `Tuple` or
 this will have fields with the same names and types as `T`.
 
 This can be overloaded for custom types if required, in which case
-[`StructArrays._getfield`](@ref) and [`StructArrays.createinstance`](@ref)
+[`StructArrays.component`](@ref) and [`StructArrays.createinstance`](@ref)
 should also be defined.
     
 ```julia-repl

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -49,7 +49,7 @@ function Base.show(io::IO, c::LazyRow)
     show(io, tup)
 end
 
-@inline Base.@propagate_inbounds _getfield(l::LazyRow, key) = getproperty(l, key)
+@inline Base.@propagate_inbounds component(l::LazyRow, key) = getproperty(l, key)
 
 staticschema(::Type{<:LazyRow{T}}) where {T} = staticschema(T)
 buildfromschema(f, ::Type{<:LazyRow{T}}) where {T} = buildfromschema(f, T)

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -45,7 +45,7 @@ Base.propertynames(c::LazyRow) = propertynames(getfield(c, 1))
 function Base.show(io::IO, c::LazyRow)
     print(io, "LazyRow")
     columns, index = getfield(c, 1), getfield(c, 2)
-    tup = StructArray(fieldarrays(columns))[index]
+    tup = StructArray(components(columns))[index]
     show(io, tup)
 end
 
@@ -75,11 +75,10 @@ struct LazyRows{T, N, C, I} <: AbstractArray{LazyRow{T, N, C, I}, N}
     columns::StructArray{T, N, C, I}
 end
 Base.parent(v::LazyRows) = getfield(v, 1)
-fieldarrays(v::LazyRows) = fieldarrays(parent(v))
-getfieldarray(v::LazyRows, key) = getfieldarray(parent(v), key)
+components(v::LazyRows) = components(parent(v))
 
-Base.getproperty(v::LazyRows, key::Symbol) = getfieldarray(v, key)
-Base.getproperty(v::LazyRows, key::Int) = getfieldarray(v, key)
+Base.getproperty(v::LazyRows, key::Symbol) = getfield(components(v), key)
+Base.getproperty(v::LazyRows, key::Int) = getfield(components(v), key)
 Base.propertynames(v::LazyRows) = propertynames(parent(v))
 
 Base.size(v::LazyRows) = size(parent(v))
@@ -93,6 +92,6 @@ end
 
 function Base.showarg(io::IO, s::LazyRows{T}, toplevel) where T
     print(io, "LazyRows")
-    showfields(io, Tuple(fieldarrays(s)))
+    showfields(io, Tuple(components(s)))
     toplevel && print(io, " with eltype LazyRow{", T, "}")
 end

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -51,9 +51,7 @@ end
 
 @inline Base.@propagate_inbounds _getfield(l::LazyRow, key) = getproperty(l, key)
 
-_fieldnames(::Type{<:LazyRow{T}}) where {T} = _fieldnames(T)
-_fieldtypes(::Type{<:LazyRow{T}}) where {T} = _fieldtypes(T)
-
+staticschema(::Type{<:LazyRow{T}}) where {T} = staticschema(T)
 buildfromschema(f, ::Type{<:LazyRow{T}}) where {T} = buildfromschema(f, T)
 iscompatible(::Type{<:LazyRow{R}}, ::Type{S}) where {R, S<:StructArray} = iscompatible(R, S)
 

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -77,8 +77,13 @@ end
 Base.parent(v::LazyRows) = getfield(v, 1)
 components(v::LazyRows) = components(parent(v))
 
-Base.getproperty(v::LazyRows, key::Symbol) = getfield(components(v), key)
-Base.getproperty(v::LazyRows, key::Int) = getfield(components(v), key)
+component(v::LazyRows, key) = component(parent(v), key)
+
+staticschema(::Type{LazyRows{T, N, C, I}}) where {T, N, C, I} = staticschema(C)
+createinstance(::Type{<:LazyRows{T}}, args...) where {T} = LazyRows(StructArray{T}(args))
+
+Base.getproperty(v::LazyRows, key::Symbol) = component(v, key)
+Base.getproperty(v::LazyRows, key::Int) = component(v, key)
 Base.propertynames(v::LazyRows) = propertynames(parent(v))
 
 Base.size(v::LazyRows) = size(parent(v))

--- a/src/sort.jl
+++ b/src/sort.jl
@@ -40,7 +40,7 @@ end
 
 roweq(t::Tuple{}, i, j) = true
 roweq(t::Tuple, i, j) = roweq(t[1], i, j) ? roweq(tail(t), i, j) : false
-roweq(s::StructArray, i, j) = roweq(Tuple(fieldarrays(s)), i, j)
+roweq(s::StructArray, i, j) = roweq(Tuple(components(s)), i, j)
 
 function uniquesorted(keys, perm=sortperm(keys))
     (keys[perm[idxs[1]]] for idxs in GroupPerm(keys, perm))
@@ -55,7 +55,7 @@ function finduniquesorted(keys, perm=sortperm(keys))
 end
 
 function Base.sortperm(c::StructVector{T}) where {T<:Union{Tuple, NamedTuple}}
-    cols = fieldarrays(c)
+    cols = components(c)
     x = cols[1]
     p = sortperm(x)
     if length(cols) > 1

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -232,6 +232,8 @@ function Base.similar(s::StructArray{T}, sz::Tuple) where {T}
     StructArray{T}(map(typ -> similar(typ, sz), components(s)))
 end
 
+@deprecate fieldarrays(x) components(x)
+
 """
     components(s::StructArray)
 

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -254,7 +254,7 @@ Base.getproperty(s::StructArray, key::Symbol) = getfieldarray(s, key)
 Base.getproperty(s::StructArray, key::Int) = getfieldarray(s, key)
 Base.propertynames(s::StructArray) = propertynames(fieldarrays(s))
 
-_getfield(s::StructArray, key) = getfieldarray(s, key)
+component(s::StructArray, key) = getfieldarray(s, key)
 staticschema(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = staticschema(C)
 createinstance(::Type{<:StructArray{T}}, args...) where {T} = StructArray{T}(args)
 

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -255,8 +255,7 @@ Base.getproperty(s::StructArray, key::Int) = getfieldarray(s, key)
 Base.propertynames(s::StructArray) = propertynames(fieldarrays(s))
 
 _getfield(s::StructArray, key) = getfieldarray(s, key)
-_fieldnames(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = _fieldnames(C)
-_fieldtypes(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = _fieldtypes(C)
+staticschema(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = staticschema(C)
 createinstance(::Type{<:StructArray{T}}, args...) where {T} = StructArray{T}(args)
 
 Base.size(s::StructArray) = size(fieldarrays(s)[1])

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -232,7 +232,7 @@ function Base.similar(s::StructArray{T}, sz::Tuple) where {T}
     StructArray{T}(map(typ -> similar(typ, sz), components(s)))
 end
 
-@deprecate fieldarrays(x) components(x)
+@deprecate fieldarrays(x) StructArrays.components(x)
 
 """
     components(s::StructArray)

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -248,9 +248,12 @@ julia> fieldarrays(s)
 """
 fieldarrays(s::StructArray) = getfield(s, :fieldarrays)
 
-Base.getproperty(s::StructArray, key::Symbol) = getfield(fieldarrays(s), key)
-Base.getproperty(s::StructArray, key::Int) = getfield(fieldarrays(s), key)
+_getfield(s::StructArray, key) = getfield(fieldarrays(s), key)
+
+Base.getproperty(s::StructArray, key::Symbol) = _getfield(s::StructArray, key)
+Base.getproperty(s::StructArray, key::Int) = _getfield(s::StructArray, key)
 Base.propertynames(s::StructArray) = propertynames(fieldarrays(s))
+
 
 Base.size(s::StructArray) = size(fieldarrays(s)[1])
 Base.size(s::StructArray{<:Any, <:Any, <:EmptyTup}) = (0,)

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -248,10 +248,10 @@ julia> fieldarrays(s)
 """
 fieldarrays(s::StructArray) = getfield(s, :fieldarrays)
 
-_getfield(s::StructArray, key) = getfield(fieldarrays(s), key)
+getfieldarray(s::StructArray, key) = getfield(fieldarrays(s), key)
 
-Base.getproperty(s::StructArray, key::Symbol) = _getfield(s::StructArray, key)
-Base.getproperty(s::StructArray, key::Int) = _getfield(s::StructArray, key)
+Base.getproperty(s::StructArray, key::Symbol) = getfieldarray(s::StructArray, key)
+Base.getproperty(s::StructArray, key::Int) = getfieldarray(s::StructArray, key)
 Base.propertynames(s::StructArray) = propertynames(fieldarrays(s))
 
 

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -250,10 +250,14 @@ fieldarrays(s::StructArray) = getfield(s, :fieldarrays)
 
 getfieldarray(s::StructArray, key) = getfield(fieldarrays(s), key)
 
-Base.getproperty(s::StructArray, key::Symbol) = getfieldarray(s::StructArray, key)
-Base.getproperty(s::StructArray, key::Int) = getfieldarray(s::StructArray, key)
+Base.getproperty(s::StructArray, key::Symbol) = getfieldarray(s, key)
+Base.getproperty(s::StructArray, key::Int) = getfieldarray(s, key)
 Base.propertynames(s::StructArray) = propertynames(fieldarrays(s))
 
+_getfield(s::StructArray, key) = getfieldarray(s, key)
+_fieldnames(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = _fieldnames(C)
+_fieldtypes(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = _fieldtypes(C)
+createinstance(::Type{<:StructArray{T}}, args...) where {T} = StructArray{T}(args)
 
 Base.size(s::StructArray) = size(fieldarrays(s)[1])
 Base.size(s::StructArray{<:Any, <:Any, <:EmptyTup}) = (0,)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -18,8 +18,7 @@ function try_compatible_columns(rows::R, s::StructArray) where {R}
     hasfields(T) || return nothing
     NT = staticschema(T)
     _schema(NT) == Tables.schema(rows) || return nothing
-    table = Tables.columns(rows)
-    fieldnames(NT) == propertynames(table) ? table : nothing
+    return Tables.columntable(rows)
 end
 
 function Base.append!(s::StructVector, rows)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -3,7 +3,7 @@ import Tables
 Tables.isrowtable(::Type{<:StructArray}) = true
 
 Tables.columnaccess(::Type{<:StructArray}) = true
-Tables.columns(s::StructArray) = fieldarrays(s)
+Tables.columns(s::StructArray) = components(s)
 Tables.schema(s::StructArray) = _schema(staticschema(eltype(s)))
 
 _schema(::Type{NT}) where {NT<:NamedTuple} = Tables.Schema(NT)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -62,7 +62,7 @@ function apply_f_to_vars_fields(names_types, vars)
     exprs = Expr[]
     for (name, type) in names_types
         sym = QuoteNode(name)
-        args = [Expr(:call, :_getfield, var, sym) for var in vars]
+        args = [Expr(:call, :component, var, sym) for var in vars]
         expr = if type <: StructArray
             apply_f_to_vars_fields(array_names_types(type), args)
         else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -134,7 +134,7 @@ end
 """
     StructArrays.replace_storage(f, s::StructArray)
 
-Change storage type for fieldarrays: each array `v` is replaced by `f(v)`. `f(v) is expected to have the same
+Change storage type for components: each array `v` is replaced by `f(v)`. `f(v) is expected to have the same
 `eltype` and `size` as `v`.
 
 ## Examples
@@ -160,7 +160,7 @@ end)
 ```
 """
 function replace_storage(f, s::StructArray{T}) where T
-    cols = fieldarrays(s)
+    cols = components(s)
     newcols = map(t -> replace_storage(f, t), cols)
     StructArray{T}(newcols)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,14 +58,11 @@ array_names_types(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = array_na
 array_names_types(::Type{NamedTuple{names, types}}) where {names, types} = zip(names, types.parameters)
 array_names_types(::Type{T}) where {T<:Tuple} = enumerate(T.parameters)
 
-getfield_or_fieldarray(s, key) = _getfield(s, key)
-getfield_or_fieldarray(s::StructArray, key) = getfieldarray(s, key)
-
 function apply_f_to_vars_fields(names_types, vars)
     exprs = Expr[]
     for (name, type) in names_types
         sym = QuoteNode(name)
-        args = [Expr(:call, :getfield_or_fieldarray, var, sym) for var in vars]
+        args = [Expr(:call, :_getfield, var, sym) for var in vars]
         expr = if type <: StructArray
             apply_f_to_vars_fields(array_names_types(type), args)
         else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -153,9 +153,9 @@ julia> s_pooled = StructArrays.replace_storage(s) do v
            isbitstype(eltype(v)) ? v : convert(PooledArray, v)
        end
 $(if VERSION < v"1.6-" 
-    "3-element StructArray(::UnitRange{Int64}, ::PooledArray{String,UInt8,1,Array{UInt8,1}}) with eltype NamedTuple{(:a, :b),Tuple{Int64,String}}:"
+    "3-element StructArray(::UnitRange{Int64}, ::PooledArray{String,UInt32,1,Array{UInt32,1}}) with eltype NamedTuple{(:a, :b),Tuple{Int64,String}}:"
 else
-        "3-element StructArray(::UnitRange{Int64}, ::PooledVector{String, UInt8, Vector{UInt8}}) with eltype NamedTuple{(:a, :b), Tuple{Int64, String}}:"
+        "3-element StructArray(::UnitRange{Int64}, ::PooledVector{String, UInt32, Vector{UInt32}}) with eltype NamedTuple{(:a, :b), Tuple{Int64, String}}:"
 end)
  (a = 1, b = "string")
  (a = 2, b = "string")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -54,13 +54,6 @@ function buildfromschema(initializer::F, ::Type{T}, ::Type{NT}) where {T, NT<:Tu
     StructArray{T}(nt)
 end
 
-@static if VERSION < v"1.2.0"
-    @inline _getproperty(v::Tuple, field) = getfield(v, field)
-    @inline _getproperty(v, field) = getproperty(v, field)
-else
-    const _getproperty = getproperty
-end
-
 array_names_types(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = array_names_types(C)
 array_names_types(::Type{NamedTuple{names, types}}) where {names, types} = zip(names, types.parameters)
 array_names_types(::Type{T}) where {T<:Tuple} = enumerate(T.parameters)
@@ -69,7 +62,7 @@ function apply_f_to_vars_fields(names_types, vars)
     exprs = Expr[]
     for (name, type) in names_types
         sym = QuoteNode(name)
-        args = [Expr(:call, :_getproperty, var, sym) for var in vars]
+        args = [Expr(:call, :_getfield, var, sym) for var in vars]
         expr = if type <: StructArray
             apply_f_to_vars_fields(array_names_types(type), args)
         else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,11 +58,14 @@ array_names_types(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = array_na
 array_names_types(::Type{NamedTuple{names, types}}) where {names, types} = zip(names, types.parameters)
 array_names_types(::Type{T}) where {T<:Tuple} = enumerate(T.parameters)
 
+getfield_or_fieldarray(s, key) = _getfield(s, key)
+getfield_or_fieldarray(s::StructArray, key) = getfieldarray(s, key)
+
 function apply_f_to_vars_fields(names_types, vars)
     exprs = Expr[]
     for (name, type) in names_types
         sym = QuoteNode(name)
-        args = [Expr(:call, :_getfield, var, sym) for var in vars]
+        args = [Expr(:call, :getfield_or_fieldarray, var, sym) for var in vars]
         expr = if type <: StructArray
             apply_f_to_vars_fields(array_names_types(type), args)
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -551,6 +551,18 @@ end
     @test sa.a isa OffsetArray
 end
 
+@testset "collectstructarrays" begin
+    s = StructArray(a = rand(10), b = rand(10))
+    t = StructArray(a = rand(10), b = rand(10))
+    v = StructArray([s, t])
+    @test v.a[1] == s.a
+    @test v.a[2] == t.a
+    @test v.b[1] == s.b
+    @test v.b[2] == t.b
+    @test v[1] == s
+    @test v[2] == t
+end
+
 @testset "hasfields" begin
     @test StructArrays.hasfields(ComplexF64)
     @test !StructArrays.hasfields(Any)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,10 +19,10 @@ doctest(StructArrays)
     @test (@inferred view(t, 2, 1:2)) == StructArray((a = view(a, 2, 1:2), b = view(b, 2, 1:2)))
 end
 
-@testset "fieldarrays" begin
+@testset "components" begin
     t = StructArray(a = 1:10, b = rand(Bool, 10))
     @test StructArrays.propertynames(t) == (:a, :b)
-    @test StructArrays.propertynames(StructArrays.fieldarrays(t)) == (:a, :b)
+    @test StructArrays.propertynames(StructArrays.components(t)) == (:a, :b)
 end
 
 @testset "utils" begin
@@ -309,7 +309,7 @@ cols_infer() = StructArray(([1, 2], [1.2, 2.3]))
     @inferred g_infer()
     @test g_infer().a.b == ["1"]
     s = @inferred tup_infer()
-    @test fieldarrays(s) == ([1, 3], [2, 4])
+    @test components(s) == ([1, 3], [2, 4])
     @test s[1] == (1, 2)
     @test s[2] == (3, 4)
     @inferred cols_infer()
@@ -474,8 +474,8 @@ end
     @test collect_structarray_rec(tuple_itr) == Float64[]
 
     t = collect_structarray_rec((a = i,) for i in (1, missing, 3))
-    @test StructArrays.fieldarrays(t)[1] isa Array{Union{Int, Missing}}
-    @test isequal(StructArrays.fieldarrays(t)[1], [1, missing, 3])
+    @test StructArrays.components(t)[1] isa Array{Union{Int, Missing}}
+    @test isequal(StructArrays.components(t)[1], [1, missing, 3])
 end
 
 pair_structarray((first, last)) = StructArray{Pair{eltype(first), eltype(last)}}((first, last))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,7 +310,7 @@ cols_infer() = StructArray(([1, 2], [1.2, 2.3]))
     @inferred g_infer()
     @test g_infer().a.b == ["1"]
     s = @inferred tup_infer()
-    @test components(s) == ([1, 3], [2, 4])
+    @test StructArrays.components(s) == ([1, 3], [2, 4])
     @test s[1] == (1, 2)
     @test s[2] == (3, 4)
     @inferred cols_infer()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -561,6 +561,16 @@ end
     @test v.b[2] == t.b
     @test v[1] == s
     @test v[2] == t
+
+    s = LazyRows(StructArray(a = rand(10), b = rand(10)))
+    t = LazyRows(StructArray(a = rand(10), b = rand(10)))
+    v = StructArray([s, t])
+    @test v.a[1] == s.a
+    @test v.a[2] == t.a
+    @test v.b[1] == s.b
+    @test v.b[2] == t.b
+    @test v[1] == s
+    @test v[2] == t
 end
 
 @testset "hasfields" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using StructArrays
 using StructArrays: staticschema, iscompatible, _promote_typejoin, append!!
 using OffsetArrays: OffsetArray
 import Tables, PooledArrays, WeakRefStrings
+using TypedTables: Table
 using DataAPI: refarray, refvalue
 using Adapt: adapt, Adapt
 using Test
@@ -340,6 +341,8 @@ end
     @test append!(StructArray([1im]), [(re = 111, im = 222)]) ==
         StructArray([1im, 111 + 222im])
     @test append!(StructArray([1im]), (x for x in [(re = 111, im = 222)])) ==
+        StructArray([1im, 111 + 222im])
+    @test append!(StructArray([1im]), Table(re = [111], im = [222])) ==
         StructArray([1im, 111 + 222im])
     # Testing integer column "names":
     @test invoke(append!, Tuple{StructVector,Any}, StructArray(([0],)), StructArray(([1],))) ==


### PR DESCRIPTION
Fix #137. This replaces the `getproperty` + `staticschema` interface with a `_getfield`, ~`_fieldtypes`, `_fieldnames`~ `staticschema` interface.

The key idea is that before there was a mismatch in the default behavior, in that by default we accessed things like `getproperty(t, n)` for `n` in `fieldnames(typeof(t))`, which could create problems for custom types that have a custom `getproperty` for reasons unrelated to StructArrays. As with the new release, broadcasting will return StructArrays by default, I think it's important that we ensure that StructArrays work out of the box with all structs.

From a user perspective the main thing that would change are the methods to overload for custom data layouts (see [here](https://github.com/JuliaArrays/StructArrays.jl#advanced-structures-with-non-standard-data-layout)).

TODO:

- [x] Update docs
- [x] Figure out what is `_getfield(s::StructArray)` ~we overload `getproperty(s::StructArray)`, but we may want to leave `_getfield(s::StructArray)` alone, I'm not sure~ (UPDATE: we overload `_getfield` and the rest of the interface)
- [x] Update `LazyRows`
- [x] Fix tests
- [x] Fix `append!` for columnar tables
- [x] Bikeshed `_getfield` name (it is now `component`)