### PR TITLE
Match `setindex!`, `push!`, and `append!` behavior of `AbstractArray` Interface

### DIFF
--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -100,3 +100,9 @@ function Base.showarg(io::IO, s::LazyRows{T}, toplevel) where T
     showfields(io, Tuple(components(s)))
     toplevel && print(io, " with eltype LazyRow{", T, "}")
 end
+
+# "materialize" / "evaluate"
+function Base.convert(::Type{T}, c::LazyRow{T}) where {T}
+    columns, index = getfield(c, 1), getfield(c, 2)
+    columns[index...]
+end

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -349,16 +349,16 @@ function Base.view(s::StructArray{T, N, C}, I...) where {T, N, C}
 end
 
 Base.@propagate_inbounds function Base.setindex!(s::StructArray{T}, vals, arg, args...) where {T}
-    setindex!(s, convert(T, vals), arg, args...)
+    _setindex!(s, convert(T, vals), arg, args...)
 end
 
-Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, vals::T, I::Vararg{Int, N}) where {T, N}
+Base.@propagate_inbounds function _setindex!(s::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, vals::T, I::Vararg{Int, N}) where {T, N}
     @boundscheck checkbounds(s, I...)
     foreachfield((col, val) -> (@inbounds col[I...] = val), s, vals)
     s
 end
 
-Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, Int}, vals::T, I::Int) where {T}
+Base.@propagate_inbounds function _setindex!(s::StructArray{T, <:Any, <:Any, Int}, vals::T, I::Int) where {T}
     @boundscheck checkbounds(s, I)
     foreachfield((col, val) -> (@inbounds col[I] = val), s, vals)
     s

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -377,6 +377,12 @@ function Base.push!(s::StructVector{T}, vals::T) where T
     return s
 end
 
+function Base.append!(s::StructVector, vals::StructVector)
+    # TODO, more efficient implementation
+    foldl(push!, vals; init = s)
+    return s
+end
+
 function Base.append!(s::StructVector{T}, vals::StructVector{T}) where T
     foreachfield(append!, s, vals)
     return s

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -348,17 +348,21 @@ function Base.view(s::StructArray{T, N, C}, I...) where {T, N, C}
     StructArray{T}(map(v -> view(v, I...), components(s)))
 end
 
-Base.@propagate_inbounds function Base.setindex!(s::StructArray{T}, vals, arg, args...) where {T}
-    _setindex!(s, convert(T, vals), arg, args...)
+Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, vals, I::Vararg{Int, N}) where {T, N}
+    setindex!(s, convert(T, vals), I...)
 end
 
-Base.@propagate_inbounds function _setindex!(s::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, vals::T, I::Vararg{Int, N}) where {T, N}
+Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, Int}, vals, I::Int) where {T}
+    setindex!(s, convert(T, vals), I)
+end
+
+Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, vals::T, I::Vararg{Int, N}) where {T, N}
     @boundscheck checkbounds(s, I...)
     foreachfield((col, val) -> (@inbounds col[I...] = val), s, vals)
     s
 end
 
-Base.@propagate_inbounds function _setindex!(s::StructArray{T, <:Any, <:Any, Int}, vals::T, I::Int) where {T}
+Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, Int}, vals::T, I::Int) where {T}
     @boundscheck checkbounds(s, I)
     foreachfield((col, val) -> (@inbounds col[I] = val), s, vals)
     s

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -348,6 +348,10 @@ function Base.view(s::StructArray{T, N, C}, I...) where {T, N, C}
     StructArray{T}(map(v -> view(v, I...), components(s)))
 end
 
+Base.@propagate_inbounds function Base.setindex!(s::StructArray{T}, vals, arg, args...) where {T}
+    setindex!(s, convert(T, vals), arg, args...)
+end
+
 Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, vals::T, I::Vararg{Int, N}) where {T, N}
     @boundscheck checkbounds(s, I...)
     foreachfield((col, val) -> (@inbounds col[I...] = val), s, vals)

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -348,24 +348,24 @@ function Base.view(s::StructArray{T, N, C}, I...) where {T, N, C}
     StructArray{T}(map(v -> view(v, I...), components(s)))
 end
 
-Base.@propagate_inbounds function Base.setindex!(s::StructArray{<:Any, <:Any, <:Any, CartesianIndex{N}}, vals, I::Vararg{Int, N}) where {N}
+Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, vals::T, I::Vararg{Int, N}) where {T, N}
     @boundscheck checkbounds(s, I...)
     foreachfield((col, val) -> (@inbounds col[I...] = val), s, vals)
     s
 end
 
-Base.@propagate_inbounds function Base.setindex!(s::StructArray{<:Any, <:Any, <:Any, Int}, vals, I::Int)
+Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, Int}, vals::T, I::Int) where {T}
     @boundscheck checkbounds(s, I)
     foreachfield((col, val) -> (@inbounds col[I] = val), s, vals)
     s
 end
 
-function Base.push!(s::StructVector, vals)
+function Base.push!(s::StructVector{T}, vals::T) where T
     foreachfield(push!, s, vals)
     return s
 end
 
-function Base.append!(s::StructVector, vals::StructVector)
+function Base.append!(s::StructVector{T}, vals::StructVector{T}) where T
     foreachfield(append!, s, vals)
     return s
 end

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -368,6 +368,10 @@ Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any,
     s
 end
 
+function Base.push!(s::StructVector{T}, vals) where {T}
+    push!(s, convert(T, vals))
+end
+
 function Base.push!(s::StructVector{T}, vals::T) where T
     foreachfield(push!, s, vals)
     return s

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -358,9 +358,9 @@ end
     @test Tables.getcolumn(Tables.columns(s), :a) == [1]
     @test Tables.getcolumn(Tables.columns(s), 2) == ["test"]
     @test Tables.getcolumn(Tables.columns(s), :b) == ["test"]
-    @test_broken append!(StructArray([1im]), [(re = 111, im = 222)]) ==
+    @test append!(StructArray([1im]), [(re = 111, im = 222)]) ==
         StructArray([1im, 111 + 222im])
-    @test_broken append!(StructArray([1im]), (x for x in [(re = 111, im = 222)])) ==
+    @test append!(StructArray([1im]), (x for x in [(re = 111, im = 222)])) ==
         StructArray([1im, 111 + 222im])
     @test append!(StructArray([1im]), Table(re = [111], im = [222])) ==
         StructArray([1im, 111 + 222im])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -850,5 +850,5 @@ end
 
     soa = StructVector{Foo1}(undef, 0)
     append!(soa, StructVector([Foo2(1, 2)]))
-    @test_broken soa[1] == Foo1(-1, 3)
+    @test soa[1] == Foo1(-1, 3)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -358,9 +358,9 @@ end
     @test Tables.getcolumn(Tables.columns(s), :a) == [1]
     @test Tables.getcolumn(Tables.columns(s), 2) == ["test"]
     @test Tables.getcolumn(Tables.columns(s), :b) == ["test"]
-    @test append!(StructArray([1im]), [(re = 111, im = 222)]) ==
+    @test_broken append!(StructArray([1im]), [(re = 111, im = 222)]) ==
         StructArray([1im, 111 + 222im])
-    @test append!(StructArray([1im]), (x for x in [(re = 111, im = 222)])) ==
+    @test_broken append!(StructArray([1im]), (x for x in [(re = 111, im = 222)])) ==
         StructArray([1im, 111 + 222im])
     @test append!(StructArray([1im]), Table(re = [111], im = [222])) ==
         StructArray([1im, 111 + 222im])
@@ -850,5 +850,5 @@ end
 
     soa = StructVector{Foo1}(undef, 0)
     append!(soa, StructVector([Foo2(1, 2)]))
-    @test soa[1] == Foo1(-1, 3)
+    @test_broken soa[1] == Foo1(-1, 3)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -810,6 +810,7 @@ Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{MyArray}}, ::Type{El
     @test_throws MethodError s .+ s
 end
 
+# define two types that are "structurally" equivalent:
 struct Foo1
     x::Int
     y::Int
@@ -820,6 +821,7 @@ struct Foo2
     y::Int
 end
 
+# but not otherwise interchangeable:
 Base.convert(::Type{Foo1}, v::Foo2) = Foo1(-v.x, v.x + v.y)
 # Base.convert(::Type{Foo2}, v::Foo1) = Foo2(-v.x, v.y + v.x)
 
@@ -845,4 +847,8 @@ end
 
     @test check_setindex!_convert(StructArray)
     @test check_push!_convert(StructVector)
+
+    soa = StructVector{Foo1}(undef, 0)
+    append!(soa, StructVector([Foo2(1, 2)]))
+    @test soa[1] == Foo1(-1, 3)
 end


### PR DESCRIPTION
See https://github.com/JuliaArrays/StructArrays.jl/issues/182

There are a few TODOs with respect to efficiency, but otherwise this does not break any tests in this test suite, although it does change the behavior and so this could be a breaking change.

If someone defines for their own type a method `Base.convert(::Type{MyType}, ::NamedTuple)`, `StructArrays.jl` will disregard it, and it will in my opinion deviate from the `AbstractArray`. 

One possible way to rectify this is to introduce a wrapper `StructArrays.Structural`. Anyone who add methods to that would be committing type piracy, and so this could be a sentinel value for indicating "do the structural (not nominal) thing". 

This means a test like

```julia
@test append!(StructArray([1im]), [(re = 111, im = 222)]) == StructArray([1im, 111 + 222im])
```

would be written (now) as

```julia
@test append!(StructArray([1im]), [Structural((re = 111, im = 222))]) == StructArray([1im, 111 + 222im])
```

and it would perhaps be worthwhile to define methods such that the following worked too:

```julia
@test append!(StructArray([1im]), Structural([(re = 111, im = 222)])) == StructArray([1im, 111 + 222im])
```
