### PR TITLE
Adding support for components/broadcasting/views with StructArrays of StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.5.1"
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Adapt = "1, 2, 3"
 DataAPI = "1"
 Tables = "1"
+StaticArrays = "1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 Adapt = "1, 2, 3"
 DataAPI = "1"
-Tables = "1"
 StaticArrays = "1"
+Tables = "1"
 julia = "1"
 
 [extras]

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -13,9 +13,7 @@ include("collect.jl")
 include("sort.jl")
 include("lazy.jl")
 include("tables.jl")
-
-import StaticArrays: SArray
-include("staticarrays.jl")
+include("staticarrays_support.jl")
 
 # Implement refarray and refvalue to deal with pooled arrays and weakrefstrings effectively
 import DataAPI: refarray, refvalue

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -14,6 +14,9 @@ include("sort.jl")
 include("lazy.jl")
 include("tables.jl")
 
+import StaticArrays: SArray
+include("staticarrays.jl")
+
 # Implement refarray and refvalue to deal with pooled arrays and weakrefstrings effectively
 import DataAPI: refarray, refvalue
 using DataAPI: defaultarray

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -1,0 +1,5 @@
+# These definitions allow `StructArray` and `StaticArrays.SArray` to play nicely together.
+StructArrays.staticschema(::Type{SArray{S,T,N,L}}) where {S,T,N,L} = NTuple{L,T}
+StructArrays.createinstance(::Type{SArray{S,T,N,L}}, args...) where {S,T,N,L} =
+    SArray{S,T,N,L}(args...)
+StructArrays.component(s::SArray, i) = getindex(s, i)

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -5,7 +5,7 @@ import StaticArrays: StaticArray, tuple_prod
 
 The `staticschema` of a `StaticArray` element type is the `staticschema` of the underlying `Tuple`.
 ```julia
-julia> StructArrays.staticschema(SVector{2,Float64})
+julia> StructArrays.staticschema(SVector{2, Float64})
 Tuple{Float64, Float64}
 ```
 """

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -6,5 +6,5 @@ import StaticArrays: StaticArray, tuple_prod
         return NTuple{$(tuple_prod(S)),T}
     end
 end
-StructArrays.createinstance(::Type{T}, args...) where {T<:StaticArray} = T(args...)
+StructArrays.createinstance(::Type{T}, args...) where {T<:StaticArray} = T(args)
 StructArrays.component(s::StaticArray, i) = getindex(s, i)

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -3,7 +3,7 @@ import StaticArrays: StaticArray, tuple_prod
 """
     StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
 
-The staticschema for a StaticArray is the underlying Tuple used to store the flattened array.
+The `staticschema` of a `StaticArray` element type is the `staticschema` of the underlying `Tuple`.
 ```julia
 julia> StructArrays.staticschema(SVector{2,Float64})
 Tuple{Float64, Float64}

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -1,6 +1,6 @@
 import StaticArrays: StaticArray, tuple_prod
 
-@generated function StructArrays.staticschema(::Type{s}) where {s <: StaticArray{S,T,N}} where {S,T,N}
+@generated function StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
     return quote
         Base.@_inline_meta
         return NTuple{$(tuple_prod(S)),T}

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -12,7 +12,7 @@ Tuple{Float64, Float64}
 @generated function StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
     return quote
         Base.@_inline_meta
-        return NTuple{$(tuple_prod(S)),T}
+        return NTuple{$(tuple_prod(S)), T}
     end
 end
 StructArrays.createinstance(::Type{T}, args...) where {T<:StaticArray} = T(args)

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -1,7 +1,10 @@
-import StaticArrays: SArray
+import StaticArrays: StaticArray, tuple_prod
 
-# These definitions allow `StructArray` and `StaticArrays.SArray` to play nicely together.
-StructArrays.staticschema(::Type{SArray{S,T,N,L}}) where {S,T,N,L} = NTuple{L,T}
-StructArrays.createinstance(::Type{SArray{S,T,N,L}}, args...) where {S,T,N,L} =
-    SArray{S,T,N,L}(args...)
-StructArrays.component(s::SArray, i) = getindex(s, i)
+@generated function StructArrays.staticschema(::Type{s}) where {s <: StaticArray{S,T,N}} where {S,T,N}
+    return quote
+        Base.@_inline_meta
+        return NTuple{$(tuple_prod(S)),T}
+    end
+end
+StructArrays.createinstance(::Type{T}, args...) where {T<:StaticArray} = T(args...)
+StructArrays.component(s::T, i) where {T <: StaticArray} = getindex(s, i)

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -7,4 +7,4 @@ import StaticArrays: StaticArray, tuple_prod
     end
 end
 StructArrays.createinstance(::Type{T}, args...) where {T<:StaticArray} = T(args...)
-StructArrays.component(s::T, i) where {T <: StaticArray} = getindex(s, i)
+StructArrays.component(s::StaticArray, i) = getindex(s, i)

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -4,6 +4,10 @@ import StaticArrays: StaticArray, tuple_prod
     StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
 
 The staticschema for a StaticArray is the underlying Tuple used to store the flattened array.
+```julia
+julia> StructArrays.staticschema(SVector{2,Float64})
+Tuple{Float64, Float64}
+```
 """
 @generated function StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
     return quote

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -1,5 +1,10 @@
 import StaticArrays: StaticArray, tuple_prod
 
+"""
+    StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
+
+The staticschema for a StaticArray is the underlying Tuple used to store the flattened array.
+"""
 @generated function StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
     return quote
         Base.@_inline_meta

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -1,3 +1,5 @@
+import StaticArrays: SArray
+
 # These definitions allow `StructArray` and `StaticArrays.SArray` to play nicely together.
 StructArrays.staticschema(::Type{SArray{S,T,N,L}}) where {S,T,N,L} = NTuple{L,T}
 StructArrays.createinstance(::Type{SArray{S,T,N,L}}, args...) where {S,T,N,L} =

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -344,7 +344,7 @@ Base.@propagate_inbounds function Base.getindex(x::StructArray{T, <:Any, <:Any, 
     return createinstance(T, get_ith(cols, I)...)
 end
 
-function Base.view(s::StructArray{T, N, C}, I...) where {T, N, C}
+@inline function Base.view(s::StructArray{T, N, C}, I...) where {T, N, C}
     StructArray{T}(map(v -> view(v, I...), components(s)))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using StructArrays
 using StructArrays: staticschema, iscompatible, _promote_typejoin, append!!
 using OffsetArrays: OffsetArray
-using StaticArrays: SVector
+using StaticArrays
 import Tables, PooledArrays, WeakRefStrings
 using TypedTables: Table
 using DataAPI: refarray, refvalue
@@ -812,9 +812,18 @@ Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{MyArray}}, ::Type{El
 end
 
 @testset "staticarrays" begin
-    x = StructArray([SVector{2}(Float64[i;i+1]) for i = 1:2])
-    y = StructArray([SVector{2}(Float64[i+1;i+2]) for i = 1:2])
-    StructArrays.components(x) # ([1.0, 2.0], [2.0, 3.0])
-    @test StructArrays.components(x) == ([1.0,2.0], [2.0,3.0])
-    @test x .+ y == StructArray([SVector{2}(Float64[2*i+1;2*i+3]) for i = 1:2])
+    # test broadcast + components for vectors
+    for StaticVectorType = [SVector, MVector, SizedVector]
+        x = StructArray([StaticVectorType{2}(Float64[i;i+1]) for i = 1:2])
+        y = StructArray([StaticVectorType{2}(Float64[i+1;i+2]) for i = 1:2])
+        @test StructArrays.components(x) == ([1.0,2.0], [2.0,3.0])
+        @test x .+ y == StructArray([StaticVectorType{2}(Float64[2*i+1;2*i+3]) for i = 1:2])
+    end
+    # test broadcast + components for general arrays
+    for StaticArrayType = [SArray, MArray, SizedArray]
+        x = StructArray([StaticArrayType{Tuple{1,2}}(ones(1,2) .+ i) for i = 0:1])
+        y = StructArray([StaticArrayType{Tuple{1,2}}(2*ones(1,2) .+ i) for i = 0:1])
+        @test StructArrays.components(x) == ([1., 2.], [1., 2.])
+        @test x .+ y == StructArray([StaticArrayType{Tuple{1,2}}(3*ones(1,2) .+ 2*i) for i = 0:1])
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -812,6 +812,12 @@ Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{MyArray}}, ::Type{El
 end
 
 @testset "staticarrays" begin
+
+    # test that staticschema returns the right things
+    for StaticVectorType = [SVector, MVector, SizedVector]    
+        @test StructArrays.staticschema(StaticVectorType{2,Float64}) == Tuple{Float64,Float64}
+    end
+
     # test broadcast + components for vectors
     for StaticVectorType = [SVector, MVector, SizedVector]
         x = @inferred StructArray([StaticVectorType{2}(Float64[i;i+1]) for i = 1:2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using StructArrays
 using StructArrays: staticschema, iscompatible, _promote_typejoin, append!!
 using OffsetArrays: OffsetArray
+using StaticArrays: SVector
 import Tables, PooledArrays, WeakRefStrings
 using TypedTables: Table
 using DataAPI: refarray, refvalue
@@ -808,4 +809,12 @@ Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{MyArray}}, ::Type{El
 
     s = StructArray{ComplexF64}((MyArray(rand(2,2)), MyArray(rand(2,2))))
     @test_throws MethodError s .+ s
+end
+
+@testset "staticarrays" begin
+    x = StructArray([SVector{2}(Float64[i;i+1]) for i = 1:2])
+    y = StructArray([SVector{2}(Float64[i+1;i+2]) for i = 1:2])
+    StructArrays.components(x) # ([1.0, 2.0], [2.0, 3.0])
+    @test StructArrays.components(x) == ([1.0,2.0], [2.0,3.0])
+    @test x .+ y == StructArray([SVector{2}(Float64[2*i+1;2*i+3]) for i = 1:2])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -818,7 +818,6 @@ end
         y = @inferred StructArray([StaticVectorType{2}(Float64[i+1;i+2]) for i = 1:2])
         @test StructArrays.components(x) == ([1.0,2.0], [2.0,3.0])
         @test x .+ y == StructArray([StaticVectorType{2}(Float64[2*i+1;2*i+3]) for i = 1:2])
-        @inferred 
     end
     # test broadcast + components for general arrays
     for StaticArrayType = [SArray, MArray, SizedArray]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -814,15 +814,16 @@ end
 @testset "staticarrays" begin
     # test broadcast + components for vectors
     for StaticVectorType = [SVector, MVector, SizedVector]
-        x = StructArray([StaticVectorType{2}(Float64[i;i+1]) for i = 1:2])
-        y = StructArray([StaticVectorType{2}(Float64[i+1;i+2]) for i = 1:2])
+        x = @inferred StructArray([StaticVectorType{2}(Float64[i;i+1]) for i = 1:2])
+        y = @inferred StructArray([StaticVectorType{2}(Float64[i+1;i+2]) for i = 1:2])
         @test StructArrays.components(x) == ([1.0,2.0], [2.0,3.0])
         @test x .+ y == StructArray([StaticVectorType{2}(Float64[2*i+1;2*i+3]) for i = 1:2])
+        @inferred 
     end
     # test broadcast + components for general arrays
     for StaticArrayType = [SArray, MArray, SizedArray]
-        x = StructArray([StaticArrayType{Tuple{1,2}}(ones(1,2) .+ i) for i = 0:1])
-        y = StructArray([StaticArrayType{Tuple{1,2}}(2*ones(1,2) .+ i) for i = 0:1])
+        x = @inferred StructArray([StaticArrayType{Tuple{1,2}}(ones(1,2) .+ i) for i = 0:1])
+        y = @inferred StructArray([StaticArrayType{Tuple{1,2}}(2*ones(1,2) .+ i) for i = 0:1])
         @test StructArrays.components(x) == ([1., 2.], [1., 2.])
         @test x .+ y == StructArray([StaticArrayType{Tuple{1,2}}(3*ones(1,2) .+ 2*i) for i = 0:1])
     end


### PR DESCRIPTION
Enables both StructArrays.components and broadcasting with StaticArray types. Fixes https://github.com/JuliaArrays/StructArrays.jl/issues/179. 