### PR TITLE
Add Base.pop! method to StructVector

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -365,6 +365,12 @@ function Base.push!(s::StructVector, vals)
     return s
 end
 
+function Base.pop!(s::StructVector)
+    out = s[end]
+    foreachfield(pop!, s)
+    return out
+end
+
 function Base.append!(s::StructVector, vals::StructVector)
     foreachfield(append!, s, vals)
     return s

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -365,10 +365,9 @@ function Base.push!(s::StructVector, vals)
     return s
 end
 
-function Base.pop!(s::StructVector)
-    out = s[end]
-    foreachfield(pop!, s)
-    return out
+function Base.pop!(s::StructVector{T}) where T
+    t = map(pop!, components(s))
+    return createinstance(T, t...)
 end
 
 function Base.append!(s::StructVector, vals::StructVector)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -222,7 +222,7 @@ end
     push!(t, (1, 2))
     @test getproperty(t, 1) == [2, 1]
     @test getproperty(t, 2) == [3.0, 2.0]
-    @test pop!(t) == (2,3.0)
+    @test pop!(t) == (1,2.0)
     @test getproperty(t, 1) == [2]
     @test getproperty(t, 2) == [3.0]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -222,7 +222,7 @@ end
     push!(t, (1, 2))
     @test getproperty(t, 1) == [2, 1]
     @test getproperty(t, 2) == [3.0, 2.0]
-    @test pop!(t) == (1,2.0)
+    @test pop!(t) == (1, 2.0)
     @test getproperty(t, 1) == [2]
     @test getproperty(t, 2) == [3.0]
 end


### PR DESCRIPTION
Exact implementation could vary from this one, but Base.pop! is desirable to have as a utility method, especially if Base.push! is already there.