### PR TITLE
improve type stability and runtime performance

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -112,7 +112,7 @@ StructVector(args...; kwargs...) = StructArray(args...; kwargs...)
 """
     StructArray{T}(A::AbstractArray; dims, unwrap=FT->FT!=eltype(A))
 
-Construct a `StructArray` from slices of `A` along `dims`. 
+Construct a `StructArray` from slices of `A` along `dims`.
 
 The `unwrap` keyword argument is a function that determines whether to
 recursively convert fields of type `FT` to `StructArray`s.

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -32,6 +32,17 @@ function index_type(::Type{T}) where {T<:Tuple}
     S, U = tuple_type_head(T), tuple_type_tail(T)
     IndexStyle(S) isa IndexCartesian ? CartesianIndex{ndims(S)} : index_type(U)
 end
+# Julia v1.7.0-beta3 doesn't seem to specialize `index_type` as defined above
+# for tuple types with "many" elements (three or four, depending on the concrete
+# types). However, we can help the compiler for homogeneous types by defining
+# the specialization below.
+function index_type(::Type{<:NTuple{N, S}}) where {N, S}
+    if IndexStyle(S) isa IndexCartesian
+        return CartesianIndex{ndims(S)}
+    else
+        return Int
+    end
+end
 
 index_type(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = I
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -87,7 +87,7 @@ end
 @generated foreachfield_gen(::S, f, xs::Vararg{Any, L}) where {S<:StructArray, L} =
     _foreachfield(array_names_types(S), L)
 
-foreachfield(f, x::StructArray, xs...) = foreachfield_gen(x, f, x, xs...)
+foreachfield(f::F, x::StructArray, xs::Vararg{Any, N}) where {F, N} = foreachfield_gen(x, f, x, xs...)
 
 """
     StructArrays.iscompatible(::Type{S}, ::Type{V}) where {S, V<:AbstractArray}
@@ -149,7 +149,7 @@ julia> s = StructArray(a=1:3, b = fill("string", 3));
 julia> s_pooled = StructArrays.replace_storage(s) do v
            isbitstype(eltype(v)) ? v : convert(PooledArray, v)
        end
-$(if VERSION < v"1.6-" 
+$(if VERSION < v"1.6-"
     "3-element StructArray(::UnitRange{Int64}, ::PooledArray{String,UInt32,1,Array{UInt32,1}}) with eltype NamedTuple{(:a, :b),Tuple{Int64,String}}:"
 else
         "3-element StructArray(::UnitRange{Int64}, ::PooledVector{String, UInt32, Vector{UInt32}}) with eltype NamedTuple{(:a, :b), Tuple{Int64, String}}:"


### PR DESCRIPTION
This is part of an effort to improve the performance of some of our numerical simulation methods for partial differential equations in [Trixi.jl](https://github.com/trixi-framework/Trixi.jl). The changes in this PR improve the performance of our methods by ca. 25%. Thus, it would be really great if this could be merged and a new version of StructArrays.jl could be registered.