### PR TITLE
implement specialization of `Base.dataids` to speed-up broadcast

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -112,7 +112,7 @@ StructVector(args...; kwargs...) = StructArray(args...; kwargs...)
 """
     StructArray{T}(A::AbstractArray; dims, unwrap=FT->FT!=eltype(A))
 
-Construct a `StructArray` from slices of `A` along `dims`. 
+Construct a `StructArray` from slices of `A` along `dims`.
 
 The `unwrap` keyword argument is a function that determines whether to
 recursively convert fields of type `FT` to `StructArray`s.
@@ -441,3 +441,6 @@ BroadcastStyle(::Type{SA}) where SA<:StructArray = StructArrayStyle{typeof(cst(S
 
 Base.similar(bc::Broadcasted{StructArrayStyle{S}}, ::Type{ElType}) where {S<:DefaultArrayStyle,N,ElType} =
     isstructtype(ElType) ? similar(StructArray{ElType}, axes(bc)) : similar(Array{ElType}, axes(bc))
+
+# for aliasing analysis during broadcast
+Base.dataids(u::StructArray) = map(Base.dataids, values(components(u)))

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -443,4 +443,4 @@ Base.similar(bc::Broadcasted{StructArrayStyle{S}}, ::Type{ElType}) where {S<:Def
     isstructtype(ElType) ? similar(StructArray{ElType}, axes(bc)) : similar(Array{ElType}, axes(bc))
 
 # for aliasing analysis during broadcast
-Base.dataids(u::StructArray) = map(Base.dataids, values(components(u)))
+Base.dataids(u::StructArray) = mapreduce(Base.dataids, (a, b) -> (a..., b...), values(components(u)), init=())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -813,6 +813,9 @@ Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{MyArray}}, ::Type{El
     @test isa(@inferred(s .+ r), StructArray)
     @test s .+ r == StructArray{ComplexF64}((s.re .+ r, s.im))
 
+    # used inside of broadcast but we also test it here explicitly
+    @test isa(@inferred(Base.dataids(s)), NTuple{N, UInt} where {N})
+
     s = StructArray{ComplexF64}((MyArray(rand(2,2)), MyArray(rand(2,2))))
     @test_throws MethodError s .+ s
 end
@@ -820,7 +823,7 @@ end
 @testset "staticarrays" begin
 
     # test that staticschema returns the right things
-    for StaticVectorType = [SVector, MVector, SizedVector]    
+    for StaticVectorType = [SVector, MVector, SizedVector]
         @test StructArrays.staticschema(StaticVectorType{2,Float64}) == Tuple{Float64,Float64}
     end
 


### PR DESCRIPTION
This is another part of an effort to improve the performance of some of our numerical simulation methods for partial differential equations in [Trixi.jl](https://github.com/trixi-framework/Trixi.jl). Adding this on top of the changes introduced in #194, this increases the performance of some of our numerical methods by ca. one third.