### PR TITLE
add missing vector methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructArrays"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -390,7 +390,7 @@ end
 
 function Base.deleteat!(s::StructVector{T}, idxs) where T
     t = map(Base.Fix2(deleteat!, idxs), components(s))
-    return createinstance(T, t...)
+    return StructVector{T}(t)
 end
 
 Base.copyto!(I::StructArray, J::StructArray) = (foreachfield(copyto!, I, J); I)

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -382,7 +382,7 @@ function Base.insert!(s::StructVector, i::Integer, vals)
 end
 
 for f in (:pop!, :popfirst!)
-    @eval function Base.$f(s::StructVector{T}, vals) where T
+    @eval function Base.$f(s::StructVector{T}) where T
         t = map($f, components(s))
         return createinstance(T, t...)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,6 +198,12 @@ end
 
     @test e == c == StructArray(a=[10,1], b=[20,2], c=["A","a"])
 
+    c = StructArray(a=[1,2,3], b=[1,4,6], c=["a","b","c"])
+    d = filter!(c) do el
+        return isodd(el.a) && iseven(el.b)
+    end
+    @test d == c == StructArray(a=[3], b=[6], c=["c"])
+
     c = StructArray{C}(a=[1], b=[2], c=["a"])
     push!(c, C(10, 20, "A"))
     @test c == StructArray{C}(a=[1,10], b=[2,20], c=["a","A"])
@@ -227,6 +233,12 @@ end
     e = prepend!(c, d)
 
     @test e == c == StructArray{C}(a=[10,1], b=[20,2], c=["A","a"])
+
+    c = StructArray{C}(a=[1,2,3], b=[1,4,6], c=["a","b","c"])
+    d = filter!(c) do el
+        return isodd(el.a) && iseven(el.b)
+    end
+    @test d == c == StructArray{C}(a=[3], b=[6], c=["c"])
 end
 
 @testset "iterators" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,6 +161,74 @@ end
     @test c == d
 end
 
+struct C
+    a::Int
+    b::Int
+    c::String
+end
+
+@testset "in-place vector methods" begin
+    c = StructArray(a=[1], b=[2], c=["a"])
+    push!(c, (a=10, b=20, c="A"))
+    @test c == StructArray(a=[1,10], b=[2,20], c=["a","A"])
+    @test pop!(c) == (a=10, b=20, c="A")
+    @test c == StructArray(a=[1], b=[2], c=["a"])
+
+    c = StructArray(a=[1], b=[2], c=["a"])
+    pushfirst!(c, (a=10, b=20, c="A"))
+    @test c == StructArray(a=[10,1], b=[20,2], c=["A","a"])
+    @test popfirst!(c) == (a=10, b=20, c="A")
+    @test c == StructArray(a=[1], b=[2], c=["a"])
+
+    c = StructArray(a=[1,2,3], b=[2,3,4], c=["a","b","c"])
+    d = insert!(c, 2, (a=10, b=20, c="A"))
+    @test d == c == StructArray(a=[1,10,2,3], b=[2,20,3,4], c=["a","A","b","c"])
+    d = deleteat!(c, 2)
+    @test d == c == StructArray(a=[1,2,3], b=[2,3,4], c=["a","b","c"])
+
+    c = StructArray(a=[1], b=[2], c=["a"])
+    d = [(a=10, b=20, c="A")]
+    e = append!(c, d)
+
+    @test e == c == StructArray(a=[1,10], b=[2,20], c=["a","A"])
+
+    c = StructArray(a=[1], b=[2], c=["a"])
+    d = [(a=10, b=20, c="A")]
+    e = prepend!(c, d)
+
+    @test e == c == StructArray(a=[10,1], b=[20,2], c=["A","a"])
+
+    c = StructArray{C}(a=[1], b=[2], c=["a"])
+    push!(c, C(10, 20, "A"))
+    @test c == StructArray{C}(a=[1,10], b=[2,20], c=["a","A"])
+    @test pop!(c) == C(10, 20, "A")
+    @test c == StructArray{C}(a=[1], b=[2], c=["a"])
+
+    c = StructArray{C}(a=[1], b=[2], c=["a"])
+    pushfirst!(c, C(10, 20, "A"))
+    @test c == StructArray{C}(a=[10,1], b=[20,2], c=["A","a"])
+    @test popfirst!(c) == C(10, 20, "A")
+    @test c == StructArray{C}(a=[1], b=[2], c=["a"])
+
+    c = StructArray{C}(a=[1,2,3], b=[2,3,4], c=["a","b","c"])
+    d = insert!(c, 2, C(10, 20, "A"))
+    @test d == c == StructArray{C}(a=[1,10,2,3], b=[2,20,3,4], c=["a","A","b","c"])
+    d = deleteat!(c, 2)
+    @test d == c == StructArray{C}(a=[1,2,3], b=[2,3,4], c=["a","b","c"])
+
+    c = StructArray{C}(a=[1], b=[2], c=["a"])
+    d = [C(10, 20, "A")]
+    e = append!(c, d)
+
+    @test e == c == StructArray{C}(a=[1,10], b=[2,20], c=["a","A"])
+
+    c = StructArray{C}(a=[1], b=[2], c=["a"])
+    d = [C(10, 20, "A")]
+    e = prepend!(c, d)
+
+    @test e == c == StructArray{C}(a=[10,1], b=[20,2], c=["A","a"])
+end
+
 @testset "iterators" begin
     c = [1, 2, 3, 1, 1]
     d = StructArrays.GroupPerm(c)


### PR DESCRIPTION
Implement missing vector methods.

Needs testing, potentially also testing that some features that arise out of composability (like `filter!`) work.

Fix #98