### PR TITLE
Revert FieldArray behavior to pre-0.6

### DIFF
--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -1,19 +1,26 @@
-import StaticArrays: SArray, tuple_prod
+import StaticArrays: StaticArray, FieldArray, tuple_prod
 
 """
-    StructArrays.staticschema(::Type{<:SArray{S, T}}) where {S, T}
+    StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
 
-The `staticschema` of an `SArray` element type is the `staticschema` of the underlying `Tuple`.
+The `staticschema` of a `StaticArray` element type is the `staticschema` of the underlying `Tuple`.
 ```julia
 julia> StructArrays.staticschema(SVector{2, Float64})
 Tuple{Float64, Float64}
 ```
+The one exception to this rule is `<:StaticArrays.FieldArray`, since `FieldArray` is based on a 
+struct. In this case, `staticschema(<:FieldArray)` returns the `staticschema` for the struct 
+which subtypes `FieldArray`. 
 """
-@generated function StructArrays.staticschema(::Type{<:SArray{S, T}}) where {S, T}
+@generated function StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
     return quote
         Base.@_inline_meta
         return NTuple{$(tuple_prod(S)), T}
     end
 end
-StructArrays.createinstance(::Type{T}, args...) where {T<:SArray} = T(args)
-StructArrays.component(s::SArray, i) = getindex(s, i)
+# invoke the general fallback for a `FieldArray` type.
+@inline function StructArrays.staticschema(T::Type{<:FieldArray})
+    invoke(StructArrays.staticschema, Tuple{Type{<:Any}}, T)
+end
+StructArrays.createinstance(::Type{T}, args...) where {T<:StaticArray} = T(args)
+StructArrays.component(s::StaticArray, i) = getindex(s, i)

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -18,9 +18,11 @@ which subtypes `FieldArray`.
         return NTuple{$(tuple_prod(S)), T}
     end
 end
-# invoke the general fallback for a `FieldArray` type.
+StructArrays.createinstance(::Type{T}, args...) where {T<:StaticArray} = T(args)
+StructArrays.component(s::StaticArray, i) = getindex(s, i)
+
+# invoke general fallbacks for a `FieldArray` type.
 @inline function StructArrays.staticschema(T::Type{<:FieldArray})
     invoke(StructArrays.staticschema, Tuple{Type{<:Any}}, T)
 end
-StructArrays.createinstance(::Type{T}, args...) where {T<:StaticArray} = T(args)
-StructArrays.component(s::StaticArray, i) = getindex(s, i)
+StructArrays.component(s::FieldArray, i) = invoke(StructArrays.component, Tuple{<:Any, <:Any}, s, i)

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -1,19 +1,19 @@
-import StaticArrays: StaticArray, tuple_prod
+import StaticArrays: SArray, tuple_prod
 
 """
-    StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
+    StructArrays.staticschema(::Type{<:SArray{S, T}}) where {S, T}
 
-The `staticschema` of a `StaticArray` element type is the `staticschema` of the underlying `Tuple`.
+The `staticschema` of an `SArray` element type is the `staticschema` of the underlying `Tuple`.
 ```julia
 julia> StructArrays.staticschema(SVector{2, Float64})
 Tuple{Float64, Float64}
 ```
 """
-@generated function StructArrays.staticschema(::Type{<:StaticArray{S, T}}) where {S, T}
+@generated function StructArrays.staticschema(::Type{<:SArray{S, T}}) where {S, T}
     return quote
         Base.@_inline_meta
         return NTuple{$(tuple_prod(S)), T}
     end
 end
-StructArrays.createinstance(::Type{T}, args...) where {T<:StaticArray} = T(args)
-StructArrays.component(s::StaticArray, i) = getindex(s, i)
+StructArrays.createinstance(::Type{T}, args...) where {T<:SArray} = T(args)
+StructArrays.component(s::SArray, i) = getindex(s, i)

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -25,4 +25,4 @@ StructArrays.component(s::StaticArray, i) = getindex(s, i)
 @inline function StructArrays.staticschema(T::Type{<:FieldArray})
     invoke(StructArrays.staticschema, Tuple{Type{<:Any}}, T)
 end
-StructArrays.component(s::FieldArray, i) = invoke(StructArrays.component, Tuple{<:Any, <:Any}, s, i)
+StructArrays.component(s::FieldArray, i) = invoke(StructArrays.component, Tuple{Any, Any}, s, i)

--- a/src/staticarrays_support.jl
+++ b/src/staticarrays_support.jl
@@ -26,3 +26,4 @@ StructArrays.component(s::StaticArray, i) = getindex(s, i)
     invoke(StructArrays.staticschema, Tuple{Type{<:Any}}, T)
 end
 StructArrays.component(s::FieldArray, i) = invoke(StructArrays.component, Tuple{Any, Any}, s, i)
+StructArrays.createinstance(T::Type{<:FieldArray}, args...) = invoke(createinstance, Tuple{Type{<:Any}, Vararg}, T, args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -850,6 +850,14 @@ end
         @test x .+ y == StructArray([StaticArrayType{Tuple{1,2}}(3*ones(1,2) .+ 2*i) for i = 0:1])
     end
 
+    # test FieldVector constructor (see https://github.com/JuliaArrays/StructArrays.jl/issues/205)
+    struct Vec2D <: FieldVector{2,Float64}
+        x::Float64
+        y::Float64
+    end
+    A = StructArray{Vec2D}((ones(5), ones(5)))
+    @test A.x == ones(5)
+
     # test type stability of creating views with "many" homogeneous components
     for n in 1:10
         u = StructArray(randn(SVector{n, Float64}) for _ in 1:10, _ in 1:5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -855,6 +855,9 @@ end
         x::Float64
         y::Float64
     end
+    # tuple constructors should respect the flipped ordering
+    FlippedVec2D(t::Tuple) = FlippedVec2D(t[2], t[1])
+
     # define a custom getindex to test StructArrays.component(::FieldArray) behavior
     Base.getindex(a::FlippedVec2D, index::Int) = index==1 ? a.y : a.x
     Base.Tuple(a::FlippedVec2D) = (a.y, a.x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -855,8 +855,9 @@ end
         x::Float64
         y::Float64
     end
-    A = StructArray{Vec2D}((ones(5), ones(5)))
-    @test A.x == ones(5)
+    a = StructArray{Vec2D}((ones(5), 2.0 * ones(5)))
+    @test a.x == ones(5)
+    @test a.y == 2 * ones(5)
 
     # test type stability of creating views with "many" homogeneous components
     for n in 1:10


### PR DESCRIPTION
Addresses https://github.com/JuliaArrays/StructArrays.jl/issues/205. 

`StructArrays.staticschema` calls `invoke` for the general fallback when the argument is `Type{<:FieldArray}`