### PR TITLE
more broadcast fixes

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -464,8 +464,8 @@ Base.@pure cst(::Type{SA}) where {SA} = combine_style_types(array_types(SA).para
 BroadcastStyle(::Type{SA}) where {SA<:StructArray} = StructArrayStyle{typeof(cst(SA)), ndims(SA)}()
 
 function Base.similar(bc::Broadcasted{StructArrayStyle{S, N}}, ::Type{ElType}) where {S<:DefaultArrayStyle, N, ElType}
-    isstruct = isstructtype(ElType) && fieldcount(ElType) > 0
-    return isstruct ? similar(StructArray{ElType}, axes(bc)) : similar(Array{ElType}, axes(bc))
+    ContainerType = isnonemptystructtype(ElType) ? StructArray{ElType} : Array{ElType}
+    return similar(ContainerType, axes(bc))
 end
 
 # for aliasing analysis during broadcast

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -449,7 +449,7 @@ struct StructArrayStyle{S, N} <: AbstractArrayStyle{N} end
 
 # Here we define the dimension tracking behavior of StructArrayStyle
 function StructArrayStyle{S, M}(::Val{N}) where {S, M, N}
-    T = S <: AbstractArrayStyle{M} ? typeof(S(Val(N))) : S
+    T = S <: AbstractArrayStyle{M} ? typeof(S(Val{N}())) : S
     return StructArrayStyle{T, N}()
 end
 
@@ -463,8 +463,10 @@ Base.@pure cst(::Type{SA}) where {SA} = combine_style_types(array_types(SA).para
 
 BroadcastStyle(::Type{SA}) where {SA<:StructArray} = StructArrayStyle{typeof(cst(SA)), ndims(SA)}()
 
-Base.similar(bc::Broadcasted{StructArrayStyle{S, N}}, ::Type{ElType}) where {S<:DefaultArrayStyle, N, ElType} =
-    isstructtype(ElType) ? similar(StructArray{ElType}, axes(bc)) : similar(Array{ElType}, axes(bc))
+function Base.similar(bc::Broadcasted{StructArrayStyle{S, N}}, ::Type{ElType}) where {S<:DefaultArrayStyle, N, ElType}
+    isstruct = isstructtype(ElType) && fieldcount(ElType) > 0
+    return isstruct ? similar(StructArray{ElType}, axes(bc)) : similar(Array{ElType}, axes(bc))
+end
 
 # for aliasing analysis during broadcast
 Base.dataids(u::StructArray) = mapreduce(Base.dataids, (a, b) -> (a..., b...), values(components(u)), init=())

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -172,6 +172,8 @@ hasfields(::Type{<:NamedTuple{names}}) where {names} = true
 hasfields(::Type{T}) where {T} = !isabstracttype(T)
 hasfields(::Union) = false
 
+isnonemptystructtype(::Type{T}) where {T} = isstructtype(T) && fieldcount(T) != 0
+
 """
     StructArrays.bypass_constructor(T, args)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -944,7 +944,12 @@ Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{MyArray}}, ::Type{El
     A = StructArray(randn(ComplexF64, 3, 3))
     B = randn(ComplexF64, 3, 3)
     c = StructArray(randn(ComplexF64, 3))
-    @test (A .= B .* c) === A
+    A .= B .* c
+    @test @inferred(B .* c) == A == B .* collect(c)
+
+    # issue #189
+    v = StructArray([(a="s1",), (a="s2",)])
+    @test @inferred(broadcast(el -> el.a, v)) == ["s1", "s2"]
 end
 
 @testset "staticarrays" begin


### PR DESCRIPTION
Fix #189. In particular, when materializing a broadcast, only materialize into a `StructArray` if the struct type has at least a field.

This is non-breaking as the previous approach errored (see #189).