### PR TITLE
implement three-argument similar method (from #94)

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -167,7 +167,7 @@ function Base.IndexStyle(::Type{S}) where {S<:StructArray}
     index_type(S) === Int ? IndexLinear() : IndexCartesian()
 end
 
-function _undef_array(::Type{T}, sz; unwrap::F = alwaysfalse) where {T, F}
+function undef_array(::Type{T}, sz; unwrap::F = alwaysfalse) where {T, F}
     if unwrap(T)
         return StructArray{T}(undef, sz; unwrap = unwrap)
     else
@@ -175,12 +175,16 @@ function _undef_array(::Type{T}, sz; unwrap::F = alwaysfalse) where {T, F}
     end
 end
 
-function _similar(v::AbstractArray, ::Type{Z}; unwrap::F = alwaysfalse) where {Z, F}
+function similar_array(v::AbstractArray, ::Type{Z}; unwrap::F = alwaysfalse) where {Z, F}
     if unwrap(Z)
-        return buildfromschema(typ -> _similar(v, typ; unwrap = unwrap), Z)
+        return buildfromschema(typ -> similar_array(v, typ; unwrap = unwrap), Z)
     else
         return similar(v, Z)
     end
+end
+
+function similar_structarray(v::AbstractArray, ::Type{Z}; unwrap::F = alwaysfalse) where {Z, F}
+    buildfromschema(typ -> similar_array(v, typ; unwrap = unwrap), Z)
 end
 
 """
@@ -204,13 +208,9 @@ julia> StructArray{ComplexF64}(undef, (2,3))
 StructArray(::Base.UndefInitializer, sz::Dims)
 
 function StructArray{T}(::Base.UndefInitializer, sz::Dims; unwrap::F = alwaysfalse) where {T, F}
-    buildfromschema(typ -> _undef_array(typ, sz; unwrap = unwrap), T)
+    buildfromschema(typ -> undef_array(typ, sz; unwrap = unwrap), T)
 end
 StructArray{T}(u::Base.UndefInitializer, d::Integer...; unwrap::F = alwaysfalse) where {T, F} = StructArray{T}(u, convert(Dims, d); unwrap = unwrap)
-
-function similar_structarray(v::AbstractArray, ::Type{Z}; unwrap::F = alwaysfalse) where {Z, F}
-    buildfromschema(typ -> _similar(v, typ; unwrap = unwrap), Z)
-end
 
 """
     StructArray(A; unwrap = T->false)
@@ -276,21 +276,37 @@ Base.convert(::Type{StructArray}, v::StructArray) = v
 Base.convert(::Type{StructVector}, v::AbstractVector) = StructVector(v)
 Base.convert(::Type{StructVector}, v::StructVector) = v
 
-function Base.similar(::Type{<:StructArray{T, N, C}}, sz::Dims) where {T, N, C}
-    return buildfromschema(typ -> similar(typ, sz), T, C)
-end
+# Mimic OffsetArrays signatures
+const OffsetAxisKnownLength = Union{Integer, AbstractUnitRange}
+const OffsetAxis = Union{OffsetAxisKnownLength, Colon}
 
-function Base.similar(s::StructArray{T}, ::Type{T}, sz::Dims) where {T}
+const OffsetShapeKnownLength = Tuple{OffsetAxisKnownLength,Vararg{OffsetAxisKnownLength}}
+const OffsetShape = Tuple{OffsetAxis,Vararg{OffsetAxis}}
+
+# Helper function to avoid adding too many dispatches to `Base.similar`
+function _similar(s::StructArray{T}, ::Type{T}, sz) where {T}
     return StructArray{T}(map(typ -> similar(typ, sz), components(s)))
 end
 
-function Base.similar(s::StructArray{T}, S::Type, sz::Dims) where {T}
+function _similar(s::StructArray{T}, S::Type, sz) where {T}
     # If not specified, we don't really know what kind of array to use for each
     # interior type, so we just pick the first one arbitrarily. If users need
     # something else, they need to be more specific.
     c1 = first(components(s))
     return isnonemptystructtype(S) ? buildfromschema(typ -> similar(c1, typ, sz), S) : similar(c1, S, sz)
 end
+
+for type in (:Dims, :OffsetShapeKnownLength)
+    @eval function Base.similar(::Type{<:StructArray{T, N, C}}, sz::$(type)) where {T, N, C}
+        return buildfromschema(typ -> similar(typ, sz), T, C)
+    end
+
+    @eval function Base.similar(s::StructArray, S::Type, sz::$(type))
+        return _similar(s, S, sz)
+    end
+end
+
+@deprecate fieldarrays(x) StructArrays.components(x)
 
 """
     components(s::StructArray)
@@ -441,8 +457,10 @@ end
 
 Base.copy(s::StructArray{T}) where {T} = StructArray{T}(map(copy, components(s)))
 
-function Base.reshape(s::StructArray{T}, d::Dims) where {T}
-    StructArray{T}(map(x -> reshape(x, d), components(s)))
+for type in (:Dims, :OffsetShape)
+    @eval function Base.reshape(s::StructArray{T}, d::$(type)) where {T}
+        StructArray{T}(map(x -> reshape(x, d), components(s)))
+    end
 end
 
 function showfields(io::IO, fields::NTuple{N, Any}) where N

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -276,26 +276,20 @@ Base.convert(::Type{StructArray}, v::StructArray) = v
 Base.convert(::Type{StructVector}, v::AbstractVector) = StructVector(v)
 Base.convert(::Type{StructVector}, v::StructVector) = v
 
-function Base.similar(::Type{<:StructArray{T, <:Any, C}}, sz::Dims) where {T, C}
-    buildfromschema(typ -> similar(typ, sz), T, C)
+function Base.similar(::Type{<:StructArray{T, N, C}}, sz::Dims) where {T, N, C}
+    return buildfromschema(typ -> similar(typ, sz), T, C)
 end
 
-Base.similar(s::StructArray, sz::Base.DimOrInd...) = similar(s, Base.to_shape(sz))
-Base.similar(s::StructArray) = similar(s, Base.to_shape(axes(s)))
-function Base.similar(s::StructArray{T,N,C}, ::Type{T}, sz::NTuple{M,Int64}) where {T, N, M, C<:Union{Tuple, NamedTuple}}
-    StructArray{T}(map(typ -> similar(typ, sz), fieldarrays(s)))
+function Base.similar(s::StructArray{T}, ::Type{T}, sz::Dims) where {T}
+    return StructArray{T}(map(typ -> similar(typ, sz), components(s)))
 end
 
-function Base.similar(s::StructArray{T,N,C}, S::Type, sz::NTuple{M,Int64}) where {T, N, M, C<:Union{Tuple, NamedTuple}}
+function Base.similar(s::StructArray{T}, S::Type, sz::Dims) where {T}
     # If not specified, we don't really know what kind of array to use for each
     # interior type, so we just pick the first one arbitrarily. If users need
     # something else, they need to be more specific.
-    f1 = fieldarrays(s)[1]
-    if isstructtype(S)
-        return StructArrays.buildfromschema(typ -> similar(f1, typ, sz), S)
-    else
-        return similar(f1, S, sz)
-    end
+    c1 = first(components(s))
+    return isnonemptystructtype(S) ? buildfromschema(typ -> similar(c1, typ, sz), S) : similar(c1, S, sz)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -325,6 +325,14 @@ end
     s = similar(t, (3, 5))
     @test eltype(s) == NamedTuple{(:a, :b), Tuple{Float64, Bool}}
     @test size(s) == (3, 5)
+
+    s = similar(t, ComplexF64, 10)
+    @test s isa StructArray{ComplexF64, 1, NamedTuple{(:re, :im), Tuple{Vector{Float64}, Vector{Float64}}}}
+    @test size(s) == (10,)
+
+    s = similar(t, Float32, 2, 2)
+    @test s isa Matrix{Float32}
+    @test size(s) == (2, 2)
 end
 
 @testset "empty" begin
@@ -1095,5 +1103,5 @@ end
 @testset "OffsetArray zero" begin
     s = StructArray{ComplexF64}((rand(2), rand(2)))
     soff = OffsetArray(s, 0:1)
-    @test isa(zero(soff).parent, StructArray)
+    @test isa(parent(zero(soff)), StructArray)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1091,3 +1091,9 @@ end
     C = map(zero, NamedTuple{(:a, :b, :c)}(map(zero, fieldtypes(types))))
     @test A === C
 end
+
+@testset "OffsetArray zero" begin
+    s = StructArray{ComplexF64}((rand(2), rand(2)))
+    soff = OffsetArray(s, 0:1)
+    @test isa(zero(soff).parent, StructArray)
+end


### PR DESCRIPTION
Rebase + cleanup of #94. I've just noticed that before there was a bit of an ambiguity in the interaction with offset arrays.

In the previous version,

```julia
julia> using StructArrays, OffsetArrays

julia> s = StructArray(a=rand(4));

julia> similar(s, -1:2) # StructArray of OffsetArrays
4-element StructArray(OffsetArray(::Vector{Float64}, -1:2)) with eltype NamedTuple{(:a,), Tuple{Float64}} with indices -1:2:
 (a = 1.4080165e-315,)
 (a = 1.408020214e-315,)
 (a = 1.396197183e-315,)
 (a = 1.402099964e-315,)

julia> similar(typeof(s), -1:2) # OffsetArray of StructArrays
4-element OffsetArray(StructArray(::Vector{Float64}), -1:2) with eltype NamedTuple{(:a,), Tuple{Float64}} with indices -1:2:
 (a = 0.0,)
 (a = 1.39654137e-315,)
 (a = 1.476201036e-315,)
 (a = 0.0,)
```

whereas with this PR they both give OffsetArrays of StructArrays:

```julia
julia> using StructArrays, OffsetArrays

julia> s = StructArray(a=rand(4));

julia> similar(s, -1:2) # OffsetArrays of StructArrays
4-element OffsetArray(StructArray(::Vector{Float64}), -1:2) with eltype NamedTuple{(:a,), Tuple{Float64}} with indices -1:2:
 (a = 0.0,)
 (a = 1.39654137e-315,)
 (a = 1.396105643e-315,)
 (a = 0.0,)

julia> similar(typeof(s), -1:2) # OffsetArray of StructArrays
4-element OffsetArray(StructArray(::Vector{Float64}), -1:2) with eltype NamedTuple{(:a,), Tuple{Float64}} with indices -1:2:
 (a = 0.0,)
 (a = 1.39654137e-315,)
 (a = 1.396105643e-315,)
 (a = 0.0,)
```

This PR behavior is kind of the only one that is clean to achieve because of the way dispatch is set up (though getting both to return StructArray of OffsetArrays is probably also feasible but a bit more finicky). Is there a principled way to know which format `similar(s::StructArray, rg::UnitRange)` should return?