### PR TITLE
improve construction and view performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructArrays"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -347,7 +347,8 @@ Base.@propagate_inbounds function Base.getindex(x::StructArray{T, <:Any, <:Any, 
 end
 
 @inline function Base.view(s::StructArray{T, N, C}, I...) where {T, N, C}
-    StructArray{T}(map(v -> view(v, I...), components(s)))
+    @boundscheck checkbounds(s, I...)
+    StructArray{T}(map(v -> @inbounds(view(v, I...)), components(s)))
 end
 
 Base.@propagate_inbounds function Base.setindex!(s::StructArray{<:Any, <:Any, <:Any, CartesianIndex{N}}, vals, I::Vararg{Int, N}) where {N}

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -15,10 +15,10 @@ struct StructArray{T, N, C<:Tup, I} <: AbstractArray{T, N}
 
     function StructArray{T, N, C}(c) where {T, N, C<:Tup}
         if length(c) > 0
-            ax = axes(c[1])
+            ax = axes(first(c))
             length(ax) == N || error("wrong number of dimensions")
-            for i = 2:length(c)
-                axes(c[i]) == ax || error("all field arrays must have same shape")
+            map(tail(c)) do ci
+                axes(ci) == ax || error("all field arrays must have same shape")
             end
         end
         new{T, N, C, index_type(c)}(c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -312,6 +312,8 @@ end
     @test pop!(t) == (1, 2.0)
     @test getproperty(t, 1) == [2]
     @test getproperty(t, 2) == [3.0]
+
+    @test_throws ErrorException StructArray(([1, 2], [3]))
 end
 
 @testset "constructor from slices" begin
@@ -350,6 +352,8 @@ end
     t2 = @inferred f2()
     @test t1 == StructArray((a=[1.2], b=["test"]))
     @test t2 == StructArray{Pair{Float64, String}}(([1.2], ["test"]))
+
+    @test_throws ErrorException StructArray(a=[1, 2], b=[3])
 end
 
 @testset "complex" begin


### PR DESCRIPTION
Make the checks type-stable, and only checkbounds once - not for each component.

Speedup example:
```julia
julia> sa = StructArray(a=rand(1:10, 10^6), b=rand(10^6), c=["abc" for _ in 1:10^6], d=[:abc for _ in 1:10^6])

# before
julia> @btime view($sa, $([5, 10, 100]))
  195.191 ns (9 allocations: 624 bytes)

# after first commit
julia> @btime view($sa, $([5, 10, 100]))
  32.490 ns (0 allocations: 0 bytes)

# after second commit
julia> @btime view($sa, $([5, 10, 100]))
  20.309 ns (0 allocations: 0 bytes)

# still significantly slower than plain Vector, but much closer than before:
julia> @btime view($(collect(sa)), $([5, 10, 100]))
  7.353 ns (0 allocations: 0 bytes)
```