### PR TITLE
fix similar() ambiguity with Base

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructArrays"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.9"
+version = "0.6.10"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
`map(f, StructArray)` stopped working in 0.6.9 due to a method ambiguity:
```julia
julia> s = StructArray(a=rand(4));

julia> map(x -> x, s)
ERROR: MethodError: similar(::StructVector{NamedTuple{(:a,), Tuple{Float64}}, NamedTuple{(:a,), Tuple{Vector{Float64}}}, Int64}, ::Type{NamedTuple{(:a,), Tuple{Float64}}}, ::Tuple{Base.OneTo{Int64}}) is ambiguous. Candidates:
  similar(a::AbstractArray, ::Type{T}, dims::Tuple{Union{Integer, Base.OneTo}, Vararg{Union{Integer, Base.OneTo}}}) where T in Base at abstractarray.jl:803
  similar(s::StructArray, S::Type, sz::Tuple{Union{Integer, AbstractUnitRange}, Vararg{Union{Integer, AbstractUnitRange}}}) in StructArrays at /home/aplavin/.julia/packages/StructArrays/5C8nj/src/structarray.jl:304
Possible fix, define
  similar(::StructArray, ::Type{T}, ::Tuple{Union{Integer, Base.OneTo}, Vararg{Union{Integer, Base.OneTo}}}) where T
```
This PR fixes the ambiguity, and adds corresponding tests.

I'm not really familiar with the `similar()` machinery, but the signature in this PR follow the Base recommendation at https://github.com/JuliaLang/julia/blob/master/base/abstractarray.jl#L810-L814. Specifically, there should be `Union{Integer, UnitRange}` (this PR) instead of `Union{Integer, AbstractUnitRange}` (0.6.9).