### PR TITLE
Support similar with nonconcrete types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructArrays"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,7 +26,7 @@ function map_params_as_tuple(f::F, ::Type{T}) where {F, T<:Tup}
         args = map(t -> :(f($t)), types)
         Expr(:tuple, args...)
     else
-        map_params_fallback(f, T)
+        map_params_as_tuple_fallback(f, T)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,6 +21,10 @@ julia> StructArrays.map_params(T -> Complex{T}, Tuple{Int32,Float64})
 map_params(f::F, ::Type{NamedTuple{names, types}}) where {F, names, types} =
     NamedTuple{names}(map_params(f, types))
 
+# pass Any when field types are not specified
+map_params(f::F, T::Type{NamedTuple{names}}) where {F, names} =
+    map_params(f, T{Tuple{fieldtypes(T)...}})
+
 function map_params(f::F, ::Type{T}) where {F, T<:Tuple}
     if @generated
         types = fieldtypes(T)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,14 +18,9 @@ julia> StructArrays.map_params(T -> Complex{T}, Tuple{Int32,Float64})
 (Complex{Int32}, Complex{Float64})
 ```
 """
-map_params(f::F, ::Type{NamedTuple{names, types}}) where {F, names, types} =
-    NamedTuple{names}(map_params(f, types))
+map_params(f::F, ::Type{T}) where {F, T<:Tup} = strip_params(T)(map_params_as_tuple(f, T))
 
-# pass Any when field types are not specified
-map_params(f::F, T::Type{NamedTuple{names}}) where {F, names} =
-    map_params(f, T{Tuple{fieldtypes(T)...}})
-
-function map_params(f::F, ::Type{T}) where {F, T<:Tuple}
+function map_params_as_tuple(f::F, ::Type{T}) where {F, T<:Tup}
     if @generated
         types = fieldtypes(T)
         args = map(t -> :(f($t)), types)
@@ -35,7 +30,7 @@ function map_params(f::F, ::Type{T}) where {F, T<:Tuple}
     end
 end
 
-map_params_fallback(f, ::Type{T}) where {T<:Tuple} = map(f, fieldtypes(T))
+map_params_as_tuple_fallback(f, ::Type{T}) where {T<:Tup} = map(f, fieldtypes(T))
 
 buildfromschema(initializer::F, ::Type{T}) where {F, T} = buildfromschema(initializer, T, staticschema(T))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1207,18 +1207,19 @@ end
     v = StructArray(rand(ComplexF64, 2, 2))
     f(T) = similar(v, T)
     types = Tuple{Int, Float64, ComplexF32, String}
-    A = @inferred StructArrays.map_params(f, types)
-    B = StructArrays.map_params_fallback(f, types)
+    A = @inferred StructArrays.map_params_as_tuple(f, types)
+    B = StructArrays.map_params_as_tuple_fallback(f, types)
     @test typeof(A) === typeof(B)
     types = Tuple{Int, Float64, ComplexF32}
     A = @inferred StructArrays.map_params(zero, types)
-    B = StructArrays.map_params_fallback(zero, types)
-    C = map(zero, fieldtypes(types))
-    @test A === B === C
+    B = map(zero, fieldtypes(types))
+    C = StructArrays.map_params_as_tuple(zero, types)
+    D = StructArrays.map_params_as_tuple_fallback(zero, types)
+    @test A === B === C === D
     namedtypes = NamedTuple{(:a, :b, :c), types}
     A = @inferred StructArrays.map_params(zero, namedtypes)
-    C = map(zero, NamedTuple{(:a, :b, :c)}(map(zero, fieldtypes(types))))
-    @test A === C
+    B = map(zero, NamedTuple{(:a, :b, :c)}(map(zero, fieldtypes(types))))
+    @test A === B
 end
 
 @testset "OffsetArray zero" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,6 +331,20 @@ end
     @test size(s) == (3, 5)
     @test s isa StructArray
 
+    s = similar(t, NamedTuple{(:x,)}, (3, 5))
+    @test eltype(s) == NamedTuple{(:x,)}
+    @test size(s) == (3, 5)
+    @test s isa StructArray
+    s = similar(t, NamedTuple{(:x,), Tuple{NamedTuple{(:y,)}}}, (3, 5))
+    @test eltype(s) == NamedTuple{(:x,), Tuple{NamedTuple{(:y,)}}}
+    @test size(s) == (3, 5)
+    @test s isa StructArray
+
+    s = similar(t, Any, (3, 5))
+    @test eltype(s) == Any
+    @test size(s) == (3, 5)
+    @test s isa Array
+
     s = similar(t, (0:2, 5))
     @test eltype(s) == NamedTuple{(:a, :b), Tuple{Float64, Bool}}
     @test axes(s) == (0:2, 1:5)
@@ -413,6 +427,10 @@ end
     @test size(t) == (5,)
     @test t == convert(StructVector, v)
     @test t == convert(StructVector, t)
+
+    t = StructVector([(a=1,), (a=missing,)])::StructVector
+    @test isequal(t.a, [1, missing])
+    @test eltype(t) <: NamedTuple{(:a,)}
 end
 
 @testset "tuple case" begin
@@ -1117,6 +1135,12 @@ end
     t = @inferred(map(x -> x.a, s))
     @test t isa Vector
     @test t == [1, 2, 3]
+
+    t = map(x -> (a=x.a,), StructVector(a=[1, missing]))::StructVector
+    @test isequal(t.a, [1, missing])
+    @test eltype(t) <: NamedTuple{(:a,)}
+    t = map(x -> (a=rand(["", 1, nothing]),), StructVector(a=1:10))::StructVector
+    @test eltype(t) <: NamedTuple{(:a,)}
 
     t = VERSION >= v"1.7" ? @inferred(map(x -> (a=x.a, b=2), s)) : map(x -> (a=x.a, b=2), s)
     @test t isa StructArray

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1206,20 +1206,37 @@ end
 @testset "map_params" begin
     v = StructArray(rand(ComplexF64, 2, 2))
     f(T) = similar(v, T)
+
     types = Tuple{Int, Float64, ComplexF32, String}
+    namedtypes = NamedTuple{(:a, :b, :c, :d), types}
     A = @inferred StructArrays.map_params_as_tuple(f, types)
     B = StructArrays.map_params_as_tuple_fallback(f, types)
-    @test typeof(A) === typeof(B)
+    C = @inferred StructArrays.map_params_as_tuple(f, namedtypes)
+    D = StructArrays.map_params_as_tuple_fallback(f, namedtypes)
+    @test typeof(A) === typeof(B) === typeof(C) === typeof(D)
+
     types = Tuple{Int, Float64, ComplexF32}
     A = @inferred StructArrays.map_params(zero, types)
     B = map(zero, fieldtypes(types))
     C = StructArrays.map_params_as_tuple(zero, types)
     D = StructArrays.map_params_as_tuple_fallback(zero, types)
     @test A === B === C === D
+
     namedtypes = NamedTuple{(:a, :b, :c), types}
     A = @inferred StructArrays.map_params(zero, namedtypes)
     B = map(zero, NamedTuple{(:a, :b, :c)}(map(zero, fieldtypes(types))))
+    C = StructArrays.map_params_as_tuple(zero, types)
+    D = StructArrays.map_params_as_tuple_fallback(zero, types)
     @test A === B
+    @test Tuple(A) === C === D
+
+    nonconcretenamedtypes = NamedTuple{(:a, :b, :c)}
+    A = @inferred StructArrays.map_params(f, nonconcretenamedtypes)
+    B = map(f, NamedTuple{(:a, :b, :c)}((Any, Any, Any)))
+    C = StructArrays.map_params_as_tuple(f, nonconcretenamedtypes)
+    D = StructArrays.map_params_as_tuple_fallback(f, nonconcretenamedtypes)
+    @test typeof(A) === typeof(B)
+    @test typeof(Tuple(A)) === typeof(C) === typeof(D)
 end
 
 @testset "OffsetArray zero" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1216,23 +1216,23 @@ end
     @test typeof(A) === typeof(B) === typeof(C) === typeof(D)
 
     types = Tuple{Int, Float64, ComplexF32}
-    A = @inferred StructArrays.map_params(zero, types)
-    B = map(zero, fieldtypes(types))
+    A = map(zero, fieldtypes(types))
+    B = @inferred StructArrays.map_params(zero, types)
     C = StructArrays.map_params_as_tuple(zero, types)
     D = StructArrays.map_params_as_tuple_fallback(zero, types)
     @test A === B === C === D
 
     namedtypes = NamedTuple{(:a, :b, :c), types}
-    A = @inferred StructArrays.map_params(zero, namedtypes)
-    B = map(zero, NamedTuple{(:a, :b, :c)}(map(zero, fieldtypes(types))))
+    A = map(zero, NamedTuple{(:a, :b, :c)}(map(zero, fieldtypes(types))))
+    B = @inferred StructArrays.map_params(zero, namedtypes)
     C = StructArrays.map_params_as_tuple(zero, types)
     D = StructArrays.map_params_as_tuple_fallback(zero, types)
     @test A === B
     @test Tuple(A) === C === D
 
     nonconcretenamedtypes = NamedTuple{(:a, :b, :c)}
-    A = @inferred StructArrays.map_params(f, nonconcretenamedtypes)
-    B = map(f, NamedTuple{(:a, :b, :c)}((Any, Any, Any)))
+    A = map(f, NamedTuple{(:a, :b, :c)}((Any, Any, Any)))
+    B = @inferred StructArrays.map_params(f, nonconcretenamedtypes)
     C = StructArrays.map_params_as_tuple(f, nonconcretenamedtypes)
     D = StructArrays.map_params_as_tuple_fallback(f, nonconcretenamedtypes)
     @test typeof(A) === typeof(B)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,14 +331,16 @@ end
     @test size(s) == (3, 5)
     @test s isa StructArray
 
-    s = similar(t, NamedTuple{(:x,)}, (3, 5))
-    @test eltype(s) == NamedTuple{(:x,)}
-    @test size(s) == (3, 5)
-    @test s isa StructArray
-    s = similar(t, NamedTuple{(:x,), Tuple{NamedTuple{(:y,)}}}, (3, 5))
-    @test eltype(s) == NamedTuple{(:x,), Tuple{NamedTuple{(:y,)}}}
-    @test size(s) == (3, 5)
-    @test s isa StructArray
+    for ET in (
+            NamedTuple{(:x,)},
+            NamedTuple{(:x,), Tuple{NamedTuple{(:y,)}}},
+            NamedTuple{(:x, :y), Tuple{Int, S}} where S
+        )
+        s = similar(t, ET, (3, 5))
+        @test eltype(s) === ET
+        @test size(s) == (3, 5)
+        @test s isa StructArray
+    end
 
     s = similar(t, Any, (3, 5))
     @test eltype(s) == Any


### PR DESCRIPTION
@aplavin, thanks for #236. I'm keeping the tests from there (and adding some more unit tests here), but I've changed to a unified implementation, otherwise it seemed like one risked missing some weird types between `NamedTuple{names}` and `NamedTuple{names, types}` (things like `T = NamedTuple{(:a, :b), Tuple{Int, S}} where S`).

I'm not sure whether those are a problem in practice, but I thought it was safer to keep a unified implementation to avoid weird corner cases.

If this makes sense to you, I'll merge and tag this soon.

Supersedes #236 