### PR TITLE
fix fancy eltypes: use ConstructionBase.constructorof

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,17 @@ version = "0.6.12"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Adapt = "1, 2, 3"
+ConstructionBase = "1"
 DataAPI = "1"
-StaticArraysCore = "1.1"
 StaticArrays = "1.5.4"
+StaticArraysCore = "1.1"
 Tables = "1"
 julia = "1.6"
 

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -1,6 +1,7 @@
 module StructArrays
 
 using Base: tail
+using ConstructionBase: constructorof
 
 export StructArray, StructVector, LazyRow, LazyRows
 export collect_structarray

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -46,7 +46,7 @@ julia> StructArrays.createinstance(Complex{Float64}, (re=1.0, im=2.0)...)
 ```
 """
 function createinstance(::Type{T}, args...) where {T}
-    isconcretetype(T) ? bypass_constructor(T, args) : T(args...)
+    isconcretetype(T) ? bypass_constructor(T, args) : constructorof(T)(args...)
 end
 
 createinstance(::Type{T}, args...) where {T<:Tup} = T(args)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -45,7 +45,7 @@ julia> StructArrays.createinstance(Complex{Float64}, (re=1.0, im=2.0)...)
 1.0 + 2.0im
 ```
 """
-function createinstance(::Type{T}, args...) where {T}
+function createinstance(::Type{T}, args...)::T where {T}
     isconcretetype(T) ? bypass_constructor(T, args) : constructorof(T)(args...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1253,3 +1253,14 @@ end
     @test zero(u) == StructArray([SVector(0.0)])
     @test typeof(zero(u)) == typeof(StructArray([SVector(0.0)]))
 end
+
+@testset "parametric type" begin
+    struct PS{A, B}
+        a::A
+        b::B
+    end
+
+    xs = StructArray([(a=1, b=2), (a=3, b=nothing)])
+    ss = map(x -> PS(x.a, x.b), xs)
+    @test ss == [PS(1, 2), PS(3, nothing)]
+end


### PR DESCRIPTION
An example of what gets fixed by this PR is added to runtests.jl: that test would fail before.