### PR TITLE
support eltypes without fields

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -333,9 +333,7 @@ staticschema(::Type{StructArray{T, N, C, I}}) where {T, N, C, I} = staticschema(
 createinstance(::Type{<:StructArray{T}}, args...) where {T} = StructArray{T}(args)
 
 Base.size(s::StructArray) = size(components(s)[1])
-Base.size(s::StructArray{<:Any, <:Any, <:EmptyTup}) = (0,)
 Base.axes(s::StructArray) = axes(components(s)[1])
-Base.axes(s::StructArray{<:Any, <:Any, <:EmptyTup}) = (1:0,)
 
 """
     StructArrays.get_ith(cols::Union{Tuple,NamedTuple}, I...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -180,10 +180,14 @@ Create an instance of type `T` from a tuple of field values `args`, bypassing
 possible internal constructors. `T` should be a concrete type.
 """
 @generated function bypass_constructor(::Type{T}, args) where {T}
-    vars = ntuple(_ -> gensym(), fieldcount(T))
-    assign = [:($var::$(fieldtype(T, i)) = getfield(args, $i)) for (i, var) in enumerate(vars)]
-    construct = Expr(:new, :T, vars...)
-    Expr(:block, assign..., construct)
+    if fieldcount(T) == 0
+        :(only(args))
+    else
+        vars = ntuple(_ -> gensym(), fieldcount(T))
+        assign = [:($var::$(fieldtype(T, i)) = getfield(args, $i)) for (i, var) in enumerate(vars)]
+        construct = Expr(:new, :T, vars...)
+        Expr(:block, assign..., construct)
+    end
 end
 
 # Specialize this for types like LazyRow that shouldn't convert

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -433,6 +433,12 @@ end
     t = StructVector([(a=1,), (a=missing,)])::StructVector
     @test isequal(t.a, [1, missing])
     @test eltype(t) <: NamedTuple{(:a,)}
+
+    @test StructArray([nothing])::StructArray == [nothing]
+    @test StructArray(Nothing[])::StructArray == Nothing[]
+    @test StructArray(1:3)::StructArray == 1:3
+    @test StructArray(Int[])::StructArray == Int[]
+    @test_broken StructArray([])::StructArray == []
 end
 
 @testset "tuple case" begin


### PR DESCRIPTION
Alternative to https://github.com/JuliaArrays/StructArrays.jl/pull/235: actually support StructArrays with eltypes that have no fields.

I regularly get bitten by stuff like `StructArray([1, 2, 3])` returning empty arrays, and ask to consider merging one of these PRs. #235 makes it throw an error instead of a silently wrong behavior, and this PR makes no-field eltypes actually work.