### PR TITLE
keep component array types when slicing

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -353,16 +353,17 @@ map(c -> c[I...], Tuple(cols))
 end
 @inline get_ith(::Tuple{}, I...) = ()
 
-Base.@propagate_inbounds function Base.getindex(x::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, I::Vararg{Int, N}) where {T, N}
+Base.@propagate_inbounds Base.getindex(x::StructArray, I...) = _getindex(x, to_indices(x, I)...)
+
+Base.@propagate_inbounds function _getindex(x::StructArray{T}, I::Vararg{Int}) where {T}
     cols = components(x)
     @boundscheck checkbounds(x, I...)
     return createinstance(T, get_ith(cols, I...)...)
 end
 
-Base.@propagate_inbounds function Base.getindex(x::StructArray{T, <:Any, <:Any, Int}, I::Int) where {T}
-    cols = components(x)
-    @boundscheck checkbounds(x, I)
-    return createinstance(T, get_ith(cols, I)...)
+@inline function _getindex(s::StructArray{T}, I...) where {T}
+    @boundscheck checkbounds(s, I...)
+    StructArray{T}(map(v -> @inbounds(getindex(v, I...)), components(s)))
 end
 
 @inline function Base.view(s::StructArray{T, N, C}, I...) where {T, N, C}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,9 @@ Base.convert(::Type{Millimeters}, x::Meters) = Millimeters(x.x*1000)
     # Test that explicit `setindex!` returns the entire array
     # (Julia's parser ensures that chained assignment returns the value)
     @test setindex!(x, 22, 3) === x
+
+    s = StructArray(a=1:5)
+    @test s[2:3].a === 2:3
 end
 
 @testset "eltype conversion" begin


### PR DESCRIPTION
Unify getindex and view to use the same approach. This helps keep component types better than the Base slicing fallback.
