### PR TITLE
make parentindices consistent with Base

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -368,6 +368,11 @@ end
     StructArray{T}(map(v -> @inbounds(view(v, I...)), components(s)))
 end
 
+function Base.parentindices(s::StructArray)
+    allequal(parentindices(c) for c in components(s)) || throw(ArgumentError("inconsistent parentindices of components"))
+    return parentindices(component(s, 1))
+end
+
 Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, vals, I::Vararg{Int, N}) where {T,N}
     @boundscheck checkbounds(s, I...)
     valsT = maybe_convert_elt(T, vals)

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -369,8 +369,9 @@ end
 end
 
 function Base.parentindices(s::StructArray)
-    allequal(parentindices(c) for c in components(s)) || throw(ArgumentError("inconsistent parentindices of components"))
-    return parentindices(component(s, 1))
+    res = parentindices(component(s, 1))
+    all(c -> parentindices(c) == res, components(s)) || throw(ArgumentError("inconsistent parentindices of components"))
+    return res
 end
 
 Base.@propagate_inbounds function Base.setindex!(s::StructArray{T, <:Any, <:Any, CartesianIndex{N}}, vals, I::Vararg{Int, N}) where {T,N}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,8 @@ Base.convert(::Type{Millimeters}, x::Meters) = Millimeters(x.x*1000)
     @test (@inferred t[2,1:2]) == StructArray((a = [3, 4], b = [6, 7]))
     @test_throws BoundsError t[3,3]
     @test (@inferred view(t, 2, 1:2)) == StructArray((a = view(a, 2, 1:2), b = view(b, 2, 1:2)))
-    @test parentindices(view(t, 2, 1:2)) == (2, 1:2)
+    @test @inferred(parentindices(view(t, 2, 1:2))) == (2, 1:2)
+    @test_throws ArgumentError parentindices(StructArray((view([1, 2], [1]), view([1, 2], [2]))))
 
     # Element type conversion (issue #216)
     x = StructArray{Complex{Int}}((a, b))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ Base.convert(::Type{Millimeters}, x::Meters) = Millimeters(x.x*1000)
     @test (@inferred t[2,1:2]) == StructArray((a = [3, 4], b = [6, 7]))
     @test_throws BoundsError t[3,3]
     @test (@inferred view(t, 2, 1:2)) == StructArray((a = view(a, 2, 1:2), b = view(b, 2, 1:2)))
+    @test parentindices(view(t, 2, 1:2)) == (2, 1:2)
 
     # Element type conversion (issue #216)
     x = StructArray{Complex{Int}}((a, b))


### PR DESCRIPTION
In Julia, the `parentindices` function returns the indices of a view in its parent array: `parentindices(view(A, I)) == (I,)`. However, for StructArray views this function always returned consecutive indices ignoring the view:
```julia
julia> A = [1+2im, 3+4im]
2-element Vector{Complex{Int64}}:
 1 + 2im
 3 + 4im

julia> SA = StructArray(A)
2-element StructArray(::Vector{Int64}, ::Vector{Int64}) with eltype Complex{Int64}:
 1 + 2im
 3 + 4im

julia> parentindices(view(A, [2]))
([2],)

julia> parentindices(view(SA, [2]))
(Base.OneTo(1),)
```

This PR fixes the above, so that `parentindices(view(SA, [2])) == parentindices(view(A, [2])) == ([2],)`.