### PR TITLE
Specialize `fill!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 Adapt = "1, 2, 3"
 DataAPI = "1"
-StaticArraysCore = "1.1"
 StaticArrays = "1.5.4"
+StaticArraysCore = "1.1"
 Tables = "1"
 julia = "1.6"
 
@@ -20,10 +20,11 @@ julia = "1.6"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [targets]
-test = ["Test", "StaticArrays", "OffsetArrays", "PooledArrays", "TypedTables", "WeakRefStrings", "Documenter"]
+test = ["Test", "StaticArrays", "OffsetArrays", "PooledArrays", "TypedTables", "WeakRefStrings", "Documenter", "SparseArrays"]

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -425,6 +425,11 @@ function Base.copyto!(I::StructArray, doffs::Integer, J::StructArray, soffs::Int
     return I
 end
 
+function Base.fill!(I::StructArray{T}, x) where {T}
+    foreachfield((I, x) -> fill!(I, x), I, convert(T, x))
+    return I
+end
+
 function Base.resize!(s::StructArray, i::Integer)
     for a in components(s)
         resize!(a, i)

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -425,10 +425,10 @@ function Base.copyto!(I::StructArray, doffs::Integer, J::StructArray, soffs::Int
     return I
 end
 
-function Base.fill!(I::StructArray{T}, x) where {T}
+function Base.fill!(s::StructArray{T}, x) where {T}
     xT = maybe_convert_elt(T, x)
-    foreachfield(fill!, I, xT)
-    return I
+    foreachfield(fill!, s, xT)
+    return s
 end
 
 function Base.resize!(s::StructArray, i::Integer)

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -426,7 +426,8 @@ function Base.copyto!(I::StructArray, doffs::Integer, J::StructArray, soffs::Int
 end
 
 function Base.fill!(I::StructArray{T}, x) where {T}
-    foreachfield((I, x) -> fill!(I, x), I, convert(T, x))
+    xT = maybe_convert_elt(T, x)
+    foreachfield((I, x) -> fill!(I, x), I, xT)
     return I
 end
 

--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -427,7 +427,7 @@ end
 
 function Base.fill!(I::StructArray{T}, x) where {T}
     xT = maybe_convert_elt(T, x)
-    foreachfield((I, x) -> fill!(I, x), I, xT)
+    foreachfield(fill!, I, xT)
     return I
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -596,6 +596,17 @@ end
         @test all(==(3), C)
     end
 
+    @testset "Tuple" begin
+        S = StructArray{Tuple{Int,Int}}(([1,2], [3,4]))
+        fill!(S, (4,5))
+        @test all(==((4,5)), S)
+
+        S = StructArray{@NamedTuple{a::Int,b::Int}}(([1,2], [3,4]))
+        fill!(S, (a=10.0, b=20.0))
+        @test all(==(10), S.a)
+        @test all(==(20), S.b)
+    end
+
     @testset "sparse matrix, complex" begin
         A = spzeros(3)
         B = spzeros(3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using TypedTables: Table
 using DataAPI: refarray, refvalue
 using Adapt: adapt, Adapt
 using Test
+using SparseArrays
 
 using Documenter: doctest
 if Base.VERSION >= v"1.6" && Int === Int64
@@ -566,6 +567,43 @@ end
     p = 1 => :c
     t[5] = p
     @test t[5] == p
+end
+
+@testset "fill!" begin
+    @testset "dense array, complex" begin
+        A = zeros(3,3)
+        B = zeros(3,3)
+        S = StructArray{Complex{eltype(A)}}((A, B))
+        fill!(S, 2+3im)
+        @test all(==(2), A)
+        @test all(==(3), B)
+    end
+
+    @testset "offset array, custom struct" begin
+        struct Vec3D{T} <: FieldVector{3, T}
+            x :: T
+            y :: T
+            z :: T
+        end
+
+        A = zeros(3:6, 3:6)
+        B = zeros(3:6, 3:6)
+        C = zeros(3:6, 3:6)
+        S = StructArray{Vec3D{eltype(A)}}((A, B, C))
+        fill!(S, Vec3D(1,2,3))
+        @test all(==(1), A)
+        @test all(==(2), B)
+        @test all(==(3), C)
+    end
+
+    @testset "sparse matrix, complex" begin
+        A = spzeros(3)
+        B = spzeros(3)
+        S = StructArray{Complex{eltype(A)}}((A,B))
+        fill!(S, 0)
+        @test all(iszero, A)
+        @test all(iszero, B)
+    end
 end
 
 @testset "concat" begin


### PR DESCRIPTION
This helps considerably with sparse parent arrays by dispatching to specialized methods instead of hitting a fallback.
On master
```julia
julia> using StructArrays, BandedMatrices, BenchmarkTools

julia> A = BandedMatrix(0 => rand(100));

julia> B = BandedMatrix(0 => rand(100));

julia> S = StructArray{Complex{eltype(A)}}((A,B));

julia> @btime $S .= 0;
  66.965 μs (0 allocations: 0 bytes)
```
This PR
```julia
julia> @btime $S .= 0;
  19.845 ns (0 allocations: 0 bytes)
```