### PR TITLE
Avoid piracy in cat

### DIFF
--- a/src/structarray.jl
+++ b/src/structarray.jl
@@ -445,10 +445,11 @@ end
 
 for op in [:cat, :hcat, :vcat]
     @eval begin
-        function Base.$op(args::StructArray...; kwargs...)
+        function Base.$op(arg1::StructArray, argsrest::StructArray...; kwargs...)
+            args = (arg1, argsrest...)
             f = key -> $op((getproperty(t, key) for t in args)...; kwargs...)
             T = mapreduce(eltype, promote_type, args)
-            StructArray{T}(map(f, propertynames(args[1])))
+            StructArray{T}(map(f, propertynames(arg1)))
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -585,6 +585,10 @@ end
     horizontal_concat = StructArray{Pair{Int, String}}(([3 1; 5 6], ["a" "a"; "b" "b"]))
     @test cat(t, t2; dims=2)::StructArray == horizontal_concat == hcat(t, t2)
     @test hcat(t, t2) isa StructArray
+
+    # check that cat(dims=1) doesn't commit type piracy (#254)
+    # We only test that this works, the return value is immaterial
+    @test cat(dims=1) == vcat()
 end
 
 f_infer() = StructArray{ComplexF64}((rand(2,2), rand(2,2)))


### PR DESCRIPTION
Currently, on master
```julia
julia> cat(dims=1)
Any[]

julia> using StructArrays

julia> cat(dims=1)
ERROR: MethodError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer
Stacktrace:
  [1] reduce_empty(op::Base.MappingRF{typeof(eltype), Base.BottomRF{typeof(promote_type)}}, #unused#::Type{Union{}})
    @ Base ./reduce.jl:356
  [2] reduce_empty_iter(op::Base.MappingRF{typeof(eltype), Base.BottomRF{typeof(promote_type)}}, itr::Tuple{}, #unused#::Base.HasEltype)
    @ Base ./reduce.jl:379
  [3] reduce_empty_iter(op::Base.MappingRF{typeof(eltype), Base.BottomRF{typeof(promote_type)}}, itr::Tuple{})
    @ Base ./reduce.jl:378
  [4] foldl_impl(op::Base.MappingRF{typeof(eltype), Base.BottomRF{typeof(promote_type)}}, nt::Base._InitialValue, itr::Tuple{})
    @ Base ./reduce.jl:49
  [5] mapfoldl_impl(f::typeof(eltype), op::typeof(promote_type), nt::Base._InitialValue, itr::Tuple{})
    @ Base ./reduce.jl:44
  [6] mapfoldl(f::Function, op::Function, itr::Tuple{}; init::Base._InitialValue)
    @ Base ./reduce.jl:170
  [7] mapfoldl
    @ ./reduce.jl:170 [inlined]
  [8] #mapreduce#263
    @ ./reduce.jl:302 [inlined]
  [9] mapreduce(f::Function, op::Function, itr::Tuple{})
    @ Base ./reduce.jl:302
 [10] cat(; kwargs::Base.Pairs{Symbol, Int64, Tuple{Symbol}, NamedTuple{(:dims,), Tuple{Int64}}})
    @ StructArrays ~/Dropbox/JuliaPackages/StructArrays.jl/src/structarray.jl:450
 [11] top-level scope
    @ REPL[2]:1
```
This PR fixes this by avoiding the accidental type piracy