### PR TITLE
faster structarray creation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructArrays"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.14"
+version = "0.6.15"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -203,8 +203,8 @@ maybe_convert_elt(::Type{T}, vals::NamedTuple) where T = T<:NamedTuple ? convert
 Compute the unique value that `f` takes on each `component ∈ componenents`.
 If not all values are equal, return `nothing`. Otherwise, return the unique value.
 """
-function findconsistentvalue(f::F, (col, cols...)::Tup) where F
-    val = f(col)
-    isconsistent = mapfoldl(isequal(val)∘f, &, cols; init=true)
+function findconsistentvalue(f::F, cols::Tup) where F
+    val = f(first(cols))
+    isconsistent = all(map(isequal(val) ∘ f, values(cols)))
     return ifelse(isconsistent, val, nothing)
 end


### PR DESCRIPTION
Much faster for small arrays:
```julia
julia> @btime StructArray(a=1:1, b=[2], c=[:a])
  111.975 ns (4 allocations: 192 bytes)  # before
  56.601 ns (2 allocations: 128 bytes)   # after

julia> @btime StructArray(a=1:1, b=2:2, c=3.:3)
  87.747 ns (3 allocations: 208 bytes)   # before
  1.750 ns (0 allocations: 0 bytes)      # after
```