### PR TITLE
Using weakdeps to reduce load time on Julia v1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+
+.vscode

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,16 @@ GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
+[weakdeps]
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[extensions]
+StructArraysGPUArraysCoreExt = "GPUArraysCore"
+StructArraysStaticArraysCoreExt = "StaticArraysCore"
+StructArraysTablesExt = "Tables"
+
 [compat]
 Adapt = "1, 2, 3"
 DataAPI = "1"
@@ -20,14 +30,17 @@ julia = "1.6"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [targets]
-test = ["Test", "JLArrays", "StaticArrays", "OffsetArrays", "PooledArrays", "TypedTables", "WeakRefStrings", "Documenter", "SparseArrays"]
+test = ["Test", "JLArrays", "StaticArrays", "OffsetArrays", "PooledArrays", "TypedTables", "WeakRefStrings", "Documenter", "SparseArrays", "GPUArraysCore", "StaticArraysCore", "Tables"]

--- a/ext/StructArraysGPUArraysCoreExt.jl
+++ b/ext/StructArraysGPUArraysCoreExt.jl
@@ -1,0 +1,21 @@
+module StructArraysGPUArraysCoreExt
+
+using StructArrays
+using StructArrays: map_params, array_types
+
+using Base: tail
+
+import GPUArraysCore
+
+# for GPU broadcast
+import GPUArraysCore
+function GPUArraysCore.backend(::Type{T}) where {T<:StructArray}
+    backends = map_params(GPUArraysCore.backend, array_types(T))
+    backend, others = backends[1], tail(backends)
+    isconsistent = mapfoldl(isequal(backend), &, others; init=true)
+    isconsistent || throw(ArgumentError("all component arrays must have the same GPU backend"))
+    return backend
+end
+StructArrays.always_struct_broadcast(::GPUArraysCore.AbstractGPUArrayStyle) = true
+
+end # module

--- a/ext/StructArraysStaticArraysCoreExt.jl
+++ b/ext/StructArraysStaticArraysCoreExt.jl
@@ -1,3 +1,10 @@
+module StructArraysStaticArraysCoreExt
+
+using StructArrays
+using StructArrays: StructArrayStyle, createinstance, replace_structarray, isnonemptystructtype
+
+using Base.Broadcast: Broadcasted
+
 using StaticArraysCore: StaticArray, FieldArray, tuple_prod
 
 """
@@ -40,7 +47,7 @@ Broadcast._axes(bc::Broadcasted{<:StructStaticArrayStyle}, ::Nothing) = axes(rep
 
 # StaticArrayStyle has no similar defined.
 # Overload `Base.copy` instead.
-@inline function try_struct_copy(bc::Broadcasted{StaticArrayStyle{M}}) where {M}
+@inline function StructArrays.try_struct_copy(bc::Broadcasted{StaticArrayStyle{M}}) where {M}
     sa = copy(bc)
     ET = eltype(sa)
     isnonemptystructtype(ET) || return sa
@@ -66,3 +73,5 @@ end
         return map(Base.Fix2(getfield, i), x)
     end
 end
+
+end # module

--- a/ext/StructArraysTablesExt.jl
+++ b/ext/StructArraysTablesExt.jl
@@ -1,3 +1,8 @@
+module StructArraysTablesExt
+
+using StructArrays
+using StructArrays: components, hasfields, foreachfield, staticschema
+
 import Tables
 
 Tables.isrowtable(::Type{<:StructArray}) = true
@@ -38,3 +43,5 @@ for (f, g) in zip((:append!, :prepend!), (:push!, :pushfirst!))
         end
     end
 end
+
+end # module

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -12,8 +12,6 @@ include("utils.jl")
 include("collect.jl")
 include("sort.jl")
 include("lazy.jl")
-include("tables.jl")
-include("staticarrays_support.jl")
 
 # Implement refarray and refvalue to deal with pooled arrays and weakrefstrings effectively
 import DataAPI: refarray, refvalue
@@ -29,15 +27,10 @@ end
 import Adapt
 Adapt.adapt_structure(to, s::StructArray) = replace_storage(x->Adapt.adapt(to, x), s)
 
-# for GPU broadcast
-import GPUArraysCore
-function GPUArraysCore.backend(::Type{T}) where {T<:StructArray}
-    backends = map_params(GPUArraysCore.backend, array_types(T))
-    backend, others = backends[1], tail(backends)
-    isconsistent = mapfoldl(isequal(backend), &, others; init=true)
-    isconsistent || throw(ArgumentError("all component arrays must have the same GPU backend"))
-    return backend
+@static if !isdefined(Base, :get_extension)
+    include("../ext/StructArraysGPUArraysCoreExt.jl")
+    include("../ext/StructArraysTablesExt.jl")
+    include("../ext/StructArraysStaticArraysCoreExt.jl")
 end
-always_struct_broadcast(::GPUArraysCore.AbstractGPUArrayStyle) = true
 
 end # module


### PR DESCRIPTION
Before (StructArrays v0.6.15):

```
julia> @time_imports import StructArrays, StaticArraysCore, Tables
      0.5 ms  DataValueInterfaces
      4.2 ms  DataAPI
      0.5 ms  IteratorInterfaceExtensions
      0.4 ms  TableTraits
    127.2 ms  Tables
      4.1 ms  StaticArraysCore
      0.2 ms  Adapt
      1.9 ms  GPUArraysCore
     34.5 ms  StructArrays
```

This PR:

```julia
julia> @time_imports import StructArrays, StaticArraysCore, Tables
      1.1 ms  DataAPI
      0.4 ms  Adapt
      1.7 ms  GPUArraysCore
     27.5 ms  StructArrays
      3.0 ms  StaticArraysCore
      0.7 ms  StructArrays → StructArraysStaticArraysCoreExt
      0.2 ms  DataValueInterfaces
      0.2 ms  IteratorInterfaceExtensions
      0.1 ms  TableTraits
     31.4 ms  Tables
      0.4 ms  StructArrays → StructArraysTablesExt
```
