### PR TITLE
Fix incorrect computation of return_type of `itr`

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -41,7 +41,7 @@ function collect_structarray(itr; initializer = default_initializer)
 end
 
 function _collect_structarray(itr::T, ::Nothing, ax; initializer = default_initializer) where {T}
-    S = @default_eltype itr
+    S = Base.@default_eltype itr
     return initializer(S, something(ax, (Base.OneTo(0),)))
 end
 

--- a/src/collect.jl
+++ b/src/collect.jl
@@ -41,7 +41,7 @@ function collect_structarray(itr; initializer = default_initializer)
 end
 
 function _collect_structarray(itr::T, ::Nothing, ax; initializer = default_initializer) where {T}
-    S = Core.Compiler.return_type(first, Tuple{T})
+    S = @default_eltype itr
     return initializer(S, something(ax, (Base.OneTo(0),)))
 end
 


### PR DESCRIPTION
The `itr` return type was assumed to be always the same as the first element. This is false for many objects, such as Tuple. Additionally, it was using a private API (Core.Compiler and
Core.Compiler.return_type) which are not stable across versions of Julia and may return weird and unpredictable answers. Switch to using the API in Base for this.