### PR TITLE
use `Base.promote_op` instead of `Core.Compiler.return_type`

### DIFF
--- a/ext/StructArraysStaticArraysExt.jl
+++ b/ext/StructArraysStaticArraysExt.jl
@@ -73,8 +73,7 @@ end
     first_staticarray = first_statictype(a...)
     elements, ET = if prod(newsize) == 0
         # Use inference to get eltype in empty case (following StaticBroadcast defined in StaticArrays.jl)
-        eltys = Tuple{map(eltype, a)...}
-        (), Core.Compiler.return_type(f, eltys)
+        (), Base.promote_op(f, map(eltype, a)...)
     else
         temp = __broadcast(f, sz, s, a...)
         temp, eltype(temp)


### PR DESCRIPTION
This moves to using a semi-documented interface from a compiler internal interface (and at the same time, fixes the issues with `Tuple{Union{}}` on 1.10).