### PR TITLE
Run Invalidations CI job on Julia v1.10

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v2
       with:
-        version: '1'
+        version: '1.10'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1


### PR DESCRIPTION
This fails on Julia v1.11 as incompatible version of dependencies are fetched