### PR TITLE
Separate deps and weakdeps in Project.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+Manifest-v*.*.toml

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,6 @@ version = "0.6.21"
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [weakdeps]

--- a/src/StructArrays.jl
+++ b/src/StructArrays.jl
@@ -39,12 +39,4 @@ colmetadata(sa::StructArray) =
         metadatasupport(typeof(col)).read ? metadata(col) : nothing
     end
 
-@static if !isdefined(Base, :get_extension)
-    include("../ext/StructArraysAdaptExt.jl")
-    include("../ext/StructArraysGPUArraysCoreExt.jl")
-    include("../ext/StructArraysSparseArraysExt.jl")
-    include("../ext/StructArraysStaticArraysExt.jl")
-    include("../ext/StructArraysLinearAlgebraExt.jl")
-end
-
 end # module


### PR DESCRIPTION
Given that this package only supports julia v1.10+ on master, we don't need to support treating weakdeps as explicit dependencies anymore. We also may remove the old code that loads the extension files explicitly if extensions are unsupported.