### PR TITLE
Release 0.7.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StructArrays"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.21"
+version = "0.7.1"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"


### PR DESCRIPTION
I propose to release StructArrays 0.7.1.

I just came across #321 and only then realized that even older fixes such as #311 are not available in StructArrays 0.7. As large parts of the Julia ecosystem, due to CompatHelper I upgraded my packages to StructArrays 0.7. As discussed in #321, I think development should focus on 0.7 and - if deemed necessary and feasible maintenance-wise - possibly fixes could be backported to a 0.6 backport release.

Fixes #321.